### PR TITLE
Changes to NS(BeamMonitor) and the particles output buffer API

### DIFF
--- a/examples/c99/track_io.c
+++ b/examples/c99/track_io.c
@@ -12,7 +12,7 @@ int main( int argc, char* argv[] )
     st_Buffer* input_pb       = SIXTRL_NULLPTR;
     st_Buffer* track_pb       = SIXTRL_NULLPTR;
     st_Buffer* eb             = SIXTRL_NULLPTR;
-    st_Buffer* io_buffer      = SIXTRL_NULLPTR;
+    st_Buffer* out_buffer     = SIXTRL_NULLPTR;
 
     st_Particles*   particles = SIXTRL_NULLPTR;
 
@@ -176,16 +176,9 @@ int main( int argc, char* argv[] )
             particles = st_Particles_add_copy(
                 track_pb, in_particles );
 
-            int ii = 0;
-
             SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
             SIXTRL_ASSERT( ( int )st_Particles_get_num_of_particles(
                 particles ) == NUM_PARTICLES );
-
-            for( ; ii < NUM_PARTICLES ; ++ii )
-            {
-                st_Particles_set_particle_id_value( particles, ii, ii );
-            }
         }
         else
         {
@@ -197,8 +190,6 @@ int main( int argc, char* argv[] )
                 int const jj = ii % in_num_particles;
                 st_Particles_copy_single( particles, ii,
                                           in_particles, jj );
-
-                st_Particles_set_particle_id_value( particles, ii, ii );
             }
         }
 
@@ -243,13 +234,13 @@ int main( int argc, char* argv[] )
             st_BeamMonitor_set_is_rolling( beam_monitor, true );
         }
 
-        io_buffer = st_Buffer_new( 0u );
+        out_buffer = st_Buffer_new( 0u );
 
-        st_BeamMonitor_prepare_io_buffer( eb, io_buffer,
-            NUM_PARTICLES, NUM_TURNS_IO_ELEM_BY_ELEM );
+        st_BeamMonitor_prepare_particles_out_buffer( eb, out_buffer,
+            particles, NUM_TURNS_IO_ELEM_BY_ELEM );
 
-        st_BeamMonitor_assign_io_buffer( eb, io_buffer,
-            NUM_PARTICLES, NUM_TURNS_IO_ELEM_BY_ELEM );
+        st_BeamMonitor_assign_particles_out_buffer( eb, out_buffer,
+            NUM_TURNS_IO_ELEM_BY_ELEM );
     }
 
     /* ********************************************************************* */
@@ -266,7 +257,7 @@ int main( int argc, char* argv[] )
         for( ; ii < NUM_TURNS_IO_ELEM_BY_ELEM ; ++ii )
         {
             st_Track_all_particles_element_by_element(
-                particles, 0u, eb, io_buffer, ii * NUM_BEAM_ELEMENTS );
+                particles, 0u, eb, out_buffer, ii * NUM_BEAM_ELEMENTS );
 
             st_Track_all_particles_increment_at_turn(
                 particles, 0u );
@@ -274,10 +265,8 @@ int main( int argc, char* argv[] )
 
         st_Track_all_particles_until_turn( particles, eb, NUM_TURNS );
 
-        st_Particles_add_copy( io_buffer, particles );
-
-        //st_Buffer_write_to_file( track_pb, path_output_particles );
-        st_Buffer_write_to_file( io_buffer, path_output_particles );
+        st_Particles_add_copy( out_buffer, particles );
+        st_Buffer_write_to_file( out_buffer, path_output_particles );
     }
 
     /* ********************************************************************* */
@@ -285,7 +274,7 @@ int main( int argc, char* argv[] )
     /* ********************************************************************* */
 
     /*
-    if( st_Buffer_get_num_of_objects( io_buffer ) ==
+    if( st_Buffer_get_num_of_objects( out_buffer ) ==
         ( ( NUM_TURNS_IO_ELEM_BY_ELEM * st_Buffer_get_num_of_objects( eb ) ) +
           ( NUM_TURNS_IO_TURN_BY_TURN ) +
           ( ( NUM_TURNS - (
@@ -293,7 +282,7 @@ int main( int argc, char* argv[] )
             / NUM_IO_SKIP ) + 1 ) )
     {
         int ii = 0;
-        printf( "Sequentially print out particles stored in io buffer: \r\n" );
+        printf( "Sequentially print out particles stored in out buffer: \r\n" );
 
         if( NUM_TURNS_IO_ELEM_BY_ELEM > 0 )
         {
@@ -314,15 +303,15 @@ int main( int argc, char* argv[] )
 
                 for( ; eb_it != eb_end ; ++eb_it, ++ii, ++kk )
                 {
-                    st_Particles const* io_particles =
-                        st_Particles_buffer_get_const_particles( io_buffer, ii );
+                    st_Particles const* out_particles =
+                        st_Particles_buffer_get_const_particles( out_buffer, ii );
 
-                    printf( "io particles | at turn = %6d | "
+                    printf( "out particles | at turn = %6d | "
                             "beam_element_id = %6d | "
                             "object_type_id = %2d ::\n",
                             jj, kk, ( int )st_Object_get_type_id( eb_it ) );
 
-                    st_Particles_print_out( io_particles );
+                    st_Particles_print_out( out_particles );
                     printf( "\r\n" );
                 }
             }
@@ -337,13 +326,13 @@ int main( int argc, char* argv[] )
             int jj = 0;
             for( ; jj < NUM_TURNS_IO_TURN_BY_TURN ; ++jj, ++ii )
             {
-                st_Particles const* io_particles =
-                    st_Particles_buffer_get_const_particles( io_buffer, ii );
+                st_Particles const* out_particles =
+                    st_Particles_buffer_get_const_particles( out_buffer, ii );
 
-                printf( "io particles | at turn = %6d ::\n",
+                printf( "out particles | at turn = %6d ::\n",
                         jj + NUM_TURNS_IO_ELEM_BY_ELEM );
 
-                st_Particles_print_out( io_particles );
+                st_Particles_print_out( out_particles );
                 printf( "\r\n" );
             }
         }
@@ -361,12 +350,12 @@ int main( int argc, char* argv[] )
             int jj = NUM_TURNS_IO_ELEM_BY_ELEM + NUM_TURNS_IO_TURN_BY_TURN;
             for( ; jj < NUM_TURNS ; jj += NUM_IO_SKIP, ++ii )
             {
-                st_Particles const* io_particles =
-                    st_Particles_buffer_get_const_particles( io_buffer, ii );
+                st_Particles const* out_particles =
+                    st_Particles_buffer_get_const_particles( out_buffer, ii );
 
-                printf( "io particles | at turn = %6d ::\n", jj );
+                printf( "out particles | at turn = %6d ::\n", jj );
 
-                st_Particles_print_out( io_particles );
+                st_Particles_print_out( out_particles );
                 printf( "\r\n" );
             }
         }
@@ -375,7 +364,7 @@ int main( int argc, char* argv[] )
                  NUM_TURNS );
 
          st_Particles_print_out( st_Particles_buffer_get_const_particles(
-             io_buffer, ii ) );
+             out_buffer, ii ) );
     }
     */
 
@@ -385,11 +374,11 @@ int main( int argc, char* argv[] )
 
     st_Buffer_delete( eb );
     st_Buffer_delete( track_pb );
-    st_Buffer_delete( io_buffer );
+    st_Buffer_delete( out_buffer );
 
     free( path_output_particles );
 
     return 0;
 }
 
-/* end: examples/c99/track_io.c */
+/* end: examples/c99/track_out.c */

--- a/sixtracklib/common/be_monitor/CMakeLists.txt
+++ b/sixtracklib/common/be_monitor/CMakeLists.txt
@@ -2,12 +2,12 @@
 
 set( SIXTRACKLIB_COMMON_BE_MONITOR_C99_HEADERS
      be_monitor.h
-     io_buffer.h
+     output_buffer.h
      track.h
 )
 
 set( SIXTRACKLIB_COMMON_BE_MONITOR_C99_SOURCES
-     io_buffer.c
+     output_buffer.c
 )
 
 set( SIXTRACKLIB_COMMON_BE_MONITOR_CXX_HEADERS

--- a/sixtracklib/common/be_monitor/be_monitor.h
+++ b/sixtracklib/common/be_monitor/be_monitor.h
@@ -33,8 +33,8 @@ typedef struct NS(BeamMonitor)
     NS(be_monitor_turn_t)   num_stores        SIXTRL_ALIGN( 8 );
     NS(be_monitor_turn_t)   start             SIXTRL_ALIGN( 8 );
     NS(be_monitor_turn_t)   skip              SIXTRL_ALIGN( 8 );
-    NS(be_monitor_addr_t)   io_address        SIXTRL_ALIGN( 8 );
-    NS(be_monitor_stride_t) io_store_stride   SIXTRL_ALIGN( 8 );
+    NS(be_monitor_addr_t)   out_address        SIXTRL_ALIGN( 8 );
+    NS(be_monitor_stride_t) out_store_stride   SIXTRL_ALIGN( 8 );
     NS(be_monitor_flag_t)   rolling           SIXTRL_ALIGN( 8 );
     NS(be_monitor_flag_t)   cont_attributes   SIXTRL_ALIGN( 8 );
 }
@@ -99,11 +99,11 @@ SIXTRL_FN SIXTRL_STATIC bool NS(BeamMonitor_are_particles_continous)(
     SIXTRL_BE_ARGPTR_DEC const NS(BeamMonitor) *const SIXTRL_RESTRICT monitor );
 
 SIXTRL_FN SIXTRL_STATIC NS(be_monitor_addr_t)
-NS(BeamMonitor_get_io_address)(
+NS(BeamMonitor_get_out_address)(
     SIXTRL_BE_ARGPTR_DEC const NS(BeamMonitor) *const SIXTRL_RESTRICT monitor );
 
 SIXTRL_FN SIXTRL_STATIC NS(be_monitor_stride_t)
-NS(BeamMonitor_get_io_store_stride)(
+NS(BeamMonitor_get_out_store_stride)(
     SIXTRL_BE_ARGPTR_DEC const NS(BeamMonitor) *const SIXTRL_RESTRICT monitor );
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -129,12 +129,12 @@ SIXTRL_FN SIXTRL_STATIC void NS(BeamMonitor_set_are_attributes_continous)(
     SIXTRL_BE_ARGPTR_DEC NS(BeamMonitor)* SIXTRL_RESTRICT monitor,
     bool const are_attributes_continous );
 
-SIXTRL_FN SIXTRL_STATIC void NS(BeamMonitor_set_io_address)(
+SIXTRL_FN SIXTRL_STATIC void NS(BeamMonitor_set_out_address)(
     SIXTRL_BE_ARGPTR_DEC NS(BeamMonitor)* SIXTRL_RESTRICT monitor,
-    NS(be_monitor_addr_t) const io_address );
+    NS(be_monitor_addr_t) const out_address );
 
 /*
-SIXTRL_FN SIXTRL_STATIC void NS(BeamMonitor_set_io_store_stride)(
+SIXTRL_FN SIXTRL_STATIC void NS(BeamMonitor_set_out_store_stride)(
     SIXTRL_BE_ARGPTR_DEC const NS(BeamMonitor) *const SIXTRL_RESTRICT monitor,
     NS(be_monitor_stride_t) const stride );
 */
@@ -156,8 +156,8 @@ SIXTRL_FN SIXTRL_STATIC SIXTRL_BUFFER_DATAPTR_DEC NS(BeamMonitor)* NS(BeamMonito
 SIXTRL_FN SIXTRL_STATIC SIXTRL_BUFFER_DATAPTR_DEC NS(BeamMonitor)* NS(BeamMonitor_add)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
     NS(be_monitor_turn_t) const num_stores, NS(be_monitor_turn_t) const start,
-    NS(be_monitor_turn_t) const skip,  NS(be_monitor_addr_t) const io_address,
-    NS(be_monitor_stride_t) const io_store_stride,
+    NS(be_monitor_turn_t) const skip,  NS(be_monitor_addr_t) const out_address,
+    NS(be_monitor_stride_t) const out_store_stride,
     bool const is_rolling, bool const are_attributes_continous );
 
 SIXTRL_FN SIXTRL_STATIC SIXTRL_BUFFER_DATAPTR_DEC NS(BeamMonitor)*
@@ -233,9 +233,9 @@ NS(BeamMonitor_preset)(
 SIXTRL_INLINE void NS(BeamMonitor_clear)(
     SIXTRL_BE_ARGPTR_DEC  NS(BeamMonitor)* SIXTRL_RESTRICT monitor )
 {
-    NS(BeamMonitor_set_io_address)( monitor, ( NS(buffer_addr_t) )0 );
-    //NS(BeamMonitor_set_io_store_stride)( monitor, ( NS(buffer_size_t) )0 );
-    if( monitor != SIXTRL_NULLPTR ) monitor->io_store_stride = 0u;
+    NS(BeamMonitor_set_out_address)( monitor, ( NS(buffer_addr_t) )0 );
+    //NS(BeamMonitor_set_out_store_stride)( monitor, ( NS(buffer_size_t) )0 );
+    if( monitor != SIXTRL_NULLPTR ) monitor->out_store_stride = 0u;
 
     return;
 }
@@ -292,11 +292,11 @@ SIXTRL_INLINE int NS(BeamMonitor_copy)(
         NS(BeamMonitor_set_are_attributes_continous)( destination,
              NS(BeamMonitor_are_attributes_continous)( source ) );
 
-        NS(BeamMonitor_set_io_address)( destination,
-            NS(BeamMonitor_get_io_address)( source ) );
+        NS(BeamMonitor_set_out_address)( destination,
+            NS(BeamMonitor_get_out_address)( source ) );
 
-        destination->io_store_stride =
-            NS(BeamMonitor_get_io_store_stride)( source );
+        destination->out_store_stride =
+            NS(BeamMonitor_get_out_store_stride)( source );
 
         success = 0;
     }
@@ -371,13 +371,13 @@ SIXTRL_INLINE int NS(BeamMonitor_compare_values)(
 
         if( compare_value == 0 )
         {
-            if( NS(BeamMonitor_get_io_address)( lhs ) >
-                NS(BeamMonitor_get_io_address)( rhs ) )
+            if( NS(BeamMonitor_get_out_address)( lhs ) >
+                NS(BeamMonitor_get_out_address)( rhs ) )
             {
                 compare_value = +1;
             }
-            else if( NS(BeamMonitor_get_io_address)( lhs ) <
-                     NS(BeamMonitor_get_io_address)( rhs ) )
+            else if( NS(BeamMonitor_get_out_address)( lhs ) <
+                     NS(BeamMonitor_get_out_address)( rhs ) )
             {
                 compare_value = -1;
             }
@@ -385,13 +385,13 @@ SIXTRL_INLINE int NS(BeamMonitor_compare_values)(
 
         if( compare_value == 0 )
         {
-            if( NS(BeamMonitor_get_io_store_stride)( lhs ) >
-                NS(BeamMonitor_get_io_store_stride)( rhs ) )
+            if( NS(BeamMonitor_get_out_store_stride)( lhs ) >
+                NS(BeamMonitor_get_out_store_stride)( rhs ) )
             {
                 compare_value = +1;
             }
-            else if( NS(BeamMonitor_get_io_store_stride)( lhs ) <
-                     NS(BeamMonitor_get_io_store_stride)( rhs ) )
+            else if( NS(BeamMonitor_get_out_store_stride)( lhs ) <
+                     NS(BeamMonitor_get_out_store_stride)( rhs ) )
             {
                 compare_value = -1;
             }
@@ -474,19 +474,19 @@ SIXTRL_INLINE bool NS(BeamMonitor_are_particles_continous)(
 }
 
 SIXTRL_INLINE NS(be_monitor_addr_t)
-NS(BeamMonitor_get_io_address)(
+NS(BeamMonitor_get_out_address)(
     SIXTRL_BE_ARGPTR_DEC const NS(BeamMonitor) *const SIXTRL_RESTRICT monitor )
 {
     SIXTRL_ASSERT( monitor != SIXTRL_NULLPTR );
-    return monitor->io_address;
+    return monitor->out_address;
 }
 
 SIXTRL_INLINE NS(be_monitor_stride_t)
-NS(BeamMonitor_get_io_store_stride)(
+NS(BeamMonitor_get_out_store_stride)(
     SIXTRL_BE_ARGPTR_DEC const NS(BeamMonitor) *const SIXTRL_RESTRICT monitor )
 {
     SIXTRL_ASSERT( monitor != SIXTRL_NULLPTR );
-    return monitor->io_store_stride;
+    return monitor->out_store_stride;
 }
 
 
@@ -535,20 +535,20 @@ SIXTRL_INLINE void NS(BeamMonitor_set_are_attributes_continous)(
     return;
 }
 
-SIXTRL_INLINE void NS(BeamMonitor_set_io_address)(
+SIXTRL_INLINE void NS(BeamMonitor_set_out_address)(
     SIXTRL_BE_ARGPTR_DEC NS(BeamMonitor)* SIXTRL_RESTRICT monitor,
-    NS(be_monitor_addr_t) const io_address )
+    NS(be_monitor_addr_t) const out_address )
 {
-    if( monitor != SIXTRL_NULLPTR ) monitor->io_address = io_address;
+    if( monitor != SIXTRL_NULLPTR ) monitor->out_address = out_address;
     return;
 }
 
 /*
-SIXTRL_INLINE void NS(BeamMonitor_set_io_store_stride)(
+SIXTRL_INLINE void NS(BeamMonitor_set_out_store_stride)(
     SIXTRL_BE_ARGPTR_DEC NS(BeamMonitor)* SIXTRL_RESTRICT monitor,
-    NS(be_monitor_stride_t) const io_store_stride )
+    NS(be_monitor_stride_t) const out_store_stride )
 {
-    if( monitor != SIXTRL_NULLPTR ) monitor->io_store_stride = io_store_stride;
+    if( monitor != SIXTRL_NULLPTR ) monitor->out_store_stride = out_store_stride;
     return;
 }
 */
@@ -598,8 +598,8 @@ SIXTRL_INLINE SIXTRL_BUFFER_DATAPTR_DEC NS(BeamMonitor)* NS(BeamMonitor_new)(
     temp_obj.start             = ( nturn_t )0u;
     temp_obj.skip              = ( nturn_t )1u;
     temp_obj.rolling           = ( flag_t )0u;
-    temp_obj.io_address        = ( addr_t )0u;
-    temp_obj.io_store_stride   = ( NS(be_monitor_stride_t) )0u;
+    temp_obj.out_address       = ( addr_t )0u;
+    temp_obj.out_store_stride  = ( NS(be_monitor_stride_t) )0u;
     temp_obj.cont_attributes   = ( flag_t )1;
 
     return ( ptr_elem_t )( uintptr_t )NS(Object_get_begin_addr)(
@@ -610,8 +610,8 @@ SIXTRL_INLINE SIXTRL_BUFFER_DATAPTR_DEC NS(BeamMonitor)* NS(BeamMonitor_new)(
 SIXTRL_INLINE SIXTRL_BUFFER_DATAPTR_DEC NS(BeamMonitor)* NS(BeamMonitor_add)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
     NS(be_monitor_turn_t) const num_stores, NS(be_monitor_turn_t) const start,
-    NS(be_monitor_turn_t) const skip,  NS(be_monitor_addr_t) const io_address,
-    NS(be_monitor_stride_t) const io_store_stride,
+    NS(be_monitor_turn_t) const skip,  NS(be_monitor_addr_t) const out_address,
+    NS(be_monitor_stride_t) const out_store_stride,
     bool const is_rolling, bool const are_attributes_continous )
 {
     typedef NS(buffer_size_t)                       buf_size_t;
@@ -625,15 +625,15 @@ SIXTRL_INLINE SIXTRL_BUFFER_DATAPTR_DEC NS(BeamMonitor)* NS(BeamMonitor_add)(
     SIXTRL_BUFFER_ARGPTR_DEC buf_size_t const* sizes   = SIXTRL_NULLPTR;
     SIXTRL_BUFFER_ARGPTR_DEC buf_size_t const* counts  = SIXTRL_NULLPTR;
 
-    SIXTRL_ASSERT( io_store_stride == ( NS(be_monitor_stride_t) )0u );
+    SIXTRL_ASSERT( out_store_stride == ( NS(be_monitor_stride_t) )0u );
 
     elem_t temp_obj;
     temp_obj.num_stores        = num_stores;
     temp_obj.start             = start;
     temp_obj.skip              = skip;
     temp_obj.rolling           = ( is_rolling ) ? 1 : 0;
-    temp_obj.io_address        = io_address;
-    temp_obj.io_store_stride   = io_store_stride;
+    temp_obj.out_address       = out_address;
+    temp_obj.out_store_stride  = out_store_stride;
     temp_obj.cont_attributes   = ( are_attributes_continous ) ? 1 : 0;
 
     return ( ptr_elem_t )( uintptr_t )NS(Object_get_begin_addr)(
@@ -650,8 +650,8 @@ NS(BeamMonitor_add_copy)(
         NS(BeamMonitor_get_num_stores)( monitor ),
         NS(BeamMonitor_get_start)( monitor ),
         NS(BeamMonitor_get_skip)( monitor ),
-        NS(BeamMonitor_get_io_address)( monitor ),
-        NS(BeamMonitor_get_io_store_stride)( monitor ),
+        NS(BeamMonitor_get_out_address)( monitor ),
+        NS(BeamMonitor_get_out_store_stride)( monitor ),
         NS(BeamMonitor_is_rolling)( monitor ),
         NS(BeamMonitor_are_attributes_continous)( monitor ) );
 }

--- a/sixtracklib/common/be_monitor/output_buffer.h
+++ b/sixtracklib/common/be_monitor/output_buffer.h
@@ -1,5 +1,5 @@
-#ifndef SIXTRACKL_COMMON_BE_MONITOR_BE_MONITOR_BE_MONITOR_IO_BUFFER_C99_H__
-#define SIXTRACKL_COMMON_BE_MONITOR_BE_MONITOR_BE_MONITOR_IO_BUFFER_C99_H__
+#ifndef SIXTRACKL_COMMON_BE_MONITOR_BE_MONITOR_BE_MONITOR_OUTPUT_BUFFER_C99_H__
+#define SIXTRACKL_COMMON_BE_MONITOR_BE_MONITOR_BE_MONITOR_OUTPUT_BUFFER_C99_H__
 
 
 #if !defined( SIXTRL_NO_SYSTEM_INCLUDES )
@@ -32,23 +32,21 @@ NS(BeamMonitor_get_num_of_beam_monitor_objects)( SIXTRL_BUFFER_ARGPTR_DEC const
 SIXTRL_FN SIXTRL_STATIC void NS(BeamMonitor_clear_all)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer );
 
-SIXTRL_HOST_FN int NS(BeamMonitor_prepare_io_buffer)(
+SIXTRL_HOST_FN int NS(BeamMonitor_prepare_particles_out_buffer)(
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT belements,
-    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT io_buffer,
-    NS(buffer_size_t) const num_particles,
+    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT out_buffer,
+    SIXTRL_PARTICLE_ARGPTR_DEC const NS(Particles) *const SIXTRL_RESTRICT particles,
     NS(buffer_size_t) const num_elem_by_elem_turns );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamMonitor_assign_io_buffer)(
+SIXTRL_FN SIXTRL_STATIC int NS(BeamMonitor_assign_particles_out_buffer)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
-    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT io_buffer,
-    NS(buffer_size_t) const num_particles,
+    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT out_buffer,
     NS(buffer_size_t) const num_elem_by_elem_turns  );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamMonitor_assign_io_buffer_from_offset)(
+SIXTRL_FN SIXTRL_STATIC int NS(BeamMonitor_assign_particles_out_buffer_from_offset)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
-    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT io_buffer,
-    NS(buffer_size_t) const num_particles,
-    NS(buffer_size_t) const io_particles_block_offset );
+    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT out_buffer,
+    NS(buffer_size_t) const out_particles_block_offset );
 
 #endif /* !defined( _GPUCODE ) */
 
@@ -66,11 +64,10 @@ SIXTRL_FN SIXTRL_STATIC void NS(BeamMonitor_clear_all_on_managed_buffer)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT beam_elements,
     NS(buffer_size_t) const slot_size );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamMonitor_assign_managed_io_buffer)(
+SIXTRL_FN SIXTRL_STATIC int NS(BeamMonitor_assign_managed_particles_out_buffer)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT beam_elements_buffer,
-    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT io_buffer,
-    NS(buffer_size_t) const num_particles,
-    NS(buffer_size_t) const io_particles_block_offset,
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT out_buffer,
+    NS(buffer_size_t) const out_particles_block_offset,
     NS(buffer_size_t) const slot_size );
 
 #if !defined(  _GPUCODE ) && defined( __cplusplus )
@@ -121,10 +118,9 @@ SIXTRL_INLINE void NS(BeamMonitor_clear_all)(
     return;
 }
 
-SIXTRL_INLINE int NS(BeamMonitor_assign_io_buffer)(
+SIXTRL_INLINE int NS(BeamMonitor_assign_particles_out_buffer)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
-    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT io_buffer,
-    NS(buffer_size_t) const num_particles,
+    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT out_buffer,
     NS(buffer_size_t) const num_elem_by_elem_turns )
 {
     typedef NS(buffer_size_t) buf_size_t;
@@ -132,12 +128,12 @@ SIXTRL_INLINE int NS(BeamMonitor_assign_io_buffer)(
     buf_size_t const slot_size = NS(Buffer_get_slot_size)(
         beam_elements_buffer );
 
-    buf_size_t const max_num_available_io_blocks =
+    buf_size_t const max_num_available_out_blocks =
         NS(Particles_managed_buffer_get_num_of_particle_blocks)(
-            NS(Buffer_get_const_data_begin)( io_buffer ), slot_size );
+            NS(Buffer_get_const_data_begin)( out_buffer ), slot_size );
 
-    buf_size_t io_particles_block_offset = ( buf_size_t )0u;
-    SIXTRL_ASSERT( slot_size == NS(Buffer_get_slot_size)( io_buffer ) );
+    buf_size_t out_particles_block_offset = ( buf_size_t )0u;
+    SIXTRL_ASSERT( slot_size == NS(Buffer_get_slot_size)( out_buffer ) );
 
     if( num_elem_by_elem_turns > ( buf_size_t )0u )
     {
@@ -149,28 +145,27 @@ SIXTRL_INLINE int NS(BeamMonitor_assign_io_buffer)(
         buf_size_t const requ_num_elem_by_elem_blocks =
             num_elem_by_elem_turns * num_elem_by_elem_blocks;
 
-        if( requ_num_elem_by_elem_blocks <= max_num_available_io_blocks )
+        if( requ_num_elem_by_elem_blocks <= max_num_available_out_blocks )
         {
-            io_particles_block_offset = requ_num_elem_by_elem_blocks;
+            out_particles_block_offset = requ_num_elem_by_elem_blocks;
         }
     }
 
-    return NS(BeamMonitor_assign_managed_io_buffer)(
+    return NS(BeamMonitor_assign_managed_particles_out_buffer)(
         NS(Buffer_get_data_begin)( beam_elements_buffer ),
-        NS(Buffer_get_data_begin)( io_buffer ), num_particles,
-        io_particles_block_offset, slot_size );
+        NS(Buffer_get_data_begin)( out_buffer ), out_particles_block_offset,
+        slot_size );
 }
 
-SIXTRL_INLINE int NS(BeamMonitor_assign_io_buffer_from_offset)(
+SIXTRL_INLINE int NS(BeamMonitor_assign_particles_out_buffer_from_offset)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
-    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT io_buffer,
-    NS(buffer_size_t) const num_particles,
-    NS(buffer_size_t) const io_particles_block_offset )
+    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT out_buffer,
+    NS(buffer_size_t) const out_particles_block_offset )
 {
-    return NS(BeamMonitor_assign_managed_io_buffer)(
+    return NS(BeamMonitor_assign_managed_particles_out_buffer)(
         NS(Buffer_get_data_begin)( beam_elements_buffer ),
-        NS(Buffer_get_data_begin)( io_buffer ), num_particles,
-        io_particles_block_offset, NS(Buffer_get_slot_size)( io_buffer ) );
+        NS(Buffer_get_data_begin)( out_buffer ),
+        out_particles_block_offset, NS(Buffer_get_slot_size)( out_buffer ) );
 }
 
 #endif /* !defined( _GPUCODE ) */
@@ -289,11 +284,10 @@ SIXTRL_INLINE void NS(BeamMonitor_clear_all_on_managed_buffer)(
 }
 
 
-SIXTRL_INLINE int NS(BeamMonitor_assign_managed_io_buffer)(
+SIXTRL_INLINE int NS(BeamMonitor_assign_managed_particles_out_buffer)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT beam_elements,
-    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT io_buffer,
-    NS(buffer_size_t) const num_particles,
-    NS(buffer_size_t) const io_particles_block_offset,
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT out_buffer,
+    NS(buffer_size_t) const out_particles_block_offset,
     NS(buffer_size_t) const slot_size )
 {
     int success = -1;
@@ -302,41 +296,49 @@ SIXTRL_INLINE int NS(BeamMonitor_assign_managed_io_buffer)(
     typedef NS(be_monitor_turn_t) nturn_t;
     typedef SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object)* ptr_obj_t;
     typedef SIXTRL_BE_ARGPTR_DEC NS(BeamMonitor)* ptr_beam_monitor_t;
+    typedef SIXTRL_BUFFER_DATAPTR_DEC NS(Particles) const* ptr_particles_t;
     typedef NS(buffer_addr_t) addr_t;
 
     SIXTRL_STATIC_VAR buf_size_t const ZERO = ( buf_size_t )0u;
 
-    buf_size_t const num_io_particle_blocks =
+    buf_size_t const num_out_particle_blocks =
         NS(Particles_managed_buffer_get_num_of_particle_blocks)(
-            io_buffer, slot_size );
+            out_buffer, slot_size );
 
-    buf_size_t num_io_particle_blocks_assigned = ZERO;
+    buf_size_t num_out_particle_blocks_assigned = ZERO;
 
     buf_size_t const num_beam_monitors =
         NS(BeamMonitor_get_num_of_beam_monitor_objects_from_managed_buffer)(
             beam_elements, slot_size );
 
-    ptr_obj_t io_it = NS(ManagedBuffer_get_objects_index_begin)(
-        io_buffer, slot_size );
+    ptr_obj_t out_it = NS(ManagedBuffer_get_objects_index_begin)(
+        out_buffer, slot_size );
 
-    ptr_obj_t io_end = NS(ManagedBuffer_get_objects_index_end)(
-        io_buffer, slot_size );
+    ptr_particles_t particles = NS(BufferIndex_get_const_particles)( out_it );
+    buf_size_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
 
-    ( void )io_end;
+    SIXTRL_ASSERT( out_it  != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( NS(ManagedBuffer_get_objects_index_end)( out_buffer,
+                    slot_size ) != SIXTRL_NULLPTR );
 
-    SIXTRL_ASSERT( io_it  != SIXTRL_NULLPTR );
-    SIXTRL_ASSERT( io_end != SIXTRL_NULLPTR );
-    SIXTRL_ASSERT( ( ( intptr_t )io_end - ( intptr_t )io_it ) >=
-                     ( intptr_t )num_io_particle_blocks );
+    SIXTRL_ASSERT( ( ( intptr_t )NS(ManagedBuffer_get_objects_index_end)(
+        out_buffer, slot_size ) - ( intptr_t )out_it ) >=
+                     ( intptr_t )num_out_particle_blocks );
 
-    success = ( ( io_particles_block_offset + num_beam_monitors ) <=
-                 num_io_particle_blocks ) ? 0 : -1;
+    SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( num_particles > ( buf_size_t )0u );
+
+    success = ( ( out_particles_block_offset + num_beam_monitors ) <=
+                 num_out_particle_blocks ) ? 0 : -1;
+
+    out_it  = out_it + out_particles_block_offset;
 
     if( ( success == 0 ) && ( num_beam_monitors > ZERO ) )
     {
         buf_size_t num_beam_monitors_assigned = ZERO;
 
-        buf_size_t const io_store_stride =
+        buf_size_t const out_store_stride =
             NS(Particles_get_required_num_slots_on_managed_buffer)(
                 num_particles, slot_size ) * slot_size;
 
@@ -346,9 +348,7 @@ SIXTRL_INLINE int NS(BeamMonitor_assign_managed_io_buffer)(
         ptr_obj_t be_end = NS(ManagedBuffer_get_objects_index_end)(
             beam_elements, slot_size );
 
-        SIXTRL_ASSERT( io_store_stride >= sizeof( NS(Particles) ) );
-
-        io_it = io_it + io_particles_block_offset;
+        SIXTRL_ASSERT( out_store_stride >= sizeof( NS(Particles) ) );
 
         SIXTRL_ASSERT( be_it  != SIXTRL_NULLPTR );
         SIXTRL_ASSERT( be_end != SIXTRL_NULLPTR );
@@ -372,11 +372,11 @@ SIXTRL_INLINE int NS(BeamMonitor_assign_managed_io_buffer)(
 
                 if( nn > 0 )
                 {
-                    if( ( num_io_particle_blocks_assigned + nn ) <=
-                          num_io_particle_blocks )
+                    if( ( num_out_particle_blocks_assigned + nn ) <=
+                          num_out_particle_blocks )
                     {
                         addr_t const paddr = ( addr_t )( uintptr_t
-                            )NS(Object_get_begin_addr)( io_it );
+                            )NS(Object_get_begin_addr)( out_it );
 
                         #if !defined( NDEBUG )
                         nturn_t kk = ( nturn_t )0;
@@ -384,19 +384,20 @@ SIXTRL_INLINE int NS(BeamMonitor_assign_managed_io_buffer)(
                         for( ; kk < nn ; ++kk )
                         {
                             SIXTRL_ASSERT( NS(Object_get_begin_addr)(
-                                io_it + kk ) == ( addr_t )(
-                                    paddr + kk * io_store_stride ) );
+                                out_it + kk ) == ( addr_t )(
+                                    paddr + kk * out_store_stride ) );
                         }
                         #endif /* !defined( NDEBUG ) */
 
-                        NS(BeamMonitor_set_io_address)( monitor, paddr );
-                        monitor->io_store_stride = io_store_stride;
+                        NS(BeamMonitor_set_out_address)( monitor, paddr );
+                        monitor->out_store_stride = out_store_stride;
 
-                        io_it = io_it + nn;
-                        num_io_particle_blocks_assigned += nn;
+                        out_it = out_it + nn;
+                        num_out_particle_blocks_assigned += nn;
 
                         SIXTRL_ASSERT( ZERO <= (
-                            ( ( uintptr_t )io_end ) - ( uintptr_t )io_it ) );
+                            ( ( uintptr_t )NS(ManagedBuffer_get_objects_index_end)(
+                                out_buffer, slot_size ) ) - ( uintptr_t )out_it ) );
                     }
                     else
                     {
@@ -419,6 +420,36 @@ SIXTRL_INLINE int NS(BeamMonitor_assign_managed_io_buffer)(
 
             if( success != 0 ) break;
         }
+
+        #if !defined( NDEBUG )
+
+        if( success == 0 )
+        {
+            ptr_obj_t it = NS(ManagedBuffer_get_objects_index_begin)(
+                out_buffer, slot_size ) + out_particles_block_offset;
+
+            ptr_obj_t out_end = it + num_beam_monitors_assigned;
+            ptr_obj_t prev = SIXTRL_NULLPTR;
+
+            for( ; it != out_end ; prev = it++ )
+            {
+                ptr_particles_t particles =
+                    NS(BufferIndex_get_const_particles)( it );
+
+                SIXTRL_ASSERT( NS(Object_get_type_id)( it ) ==
+                            NS(OBJECT_TYPE_PARTICLE) );
+
+                SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+                SIXTRL_ASSERT( num_particles == ( buf_size_t
+                    )NS(Particles_get_num_of_particles)( particles ) );
+
+                SIXTRL_ASSERT( ( prev == SIXTRL_NULLPTR ) ||
+                    ( ( NS(Object_get_begin_addr)( prev ) + out_store_stride )
+                        == NS(Object_get_begin_addr)( it ) ) );
+            }
+        }
+
+        #endif /* !defined( NDEBUG ) */
     }
 
     return success;
@@ -428,6 +459,6 @@ SIXTRL_INLINE int NS(BeamMonitor_assign_managed_io_buffer)(
 }
 #endif /* !defined(  _GPUCODE ) && defined( __cplusplus ) */
 
-#endif /* SIXTRACKL_COMMON_BE_MONITOR_BE_MONITOR_BE_MONITOR_IO_BUFFER_C99_H__ */
+#endif /* SIXTRACKL_COMMON_BE_MONITOR_BE_MONITOR_BE_MONITOR_OUTPUT_BUFFER_C99_H__ */
 
-/* end: sixtracklib/common/be_monitor/be_monitor_io_buffer.h */
+/* end: sixtracklib/common/be_monitor/output_buffer.h */

--- a/sixtracklib/common/be_monitor/track.h
+++ b/sixtracklib/common/be_monitor/track.h
@@ -117,19 +117,19 @@ SIXTRL_INLINE NS(buffer_addr_t) NS(BeamMonitor_get_particles_begin_addr)(
 {
     typedef NS(be_monitor_stride_t) stride_t;
 
-    stride_t const stride = NS(BeamMonitor_get_io_store_stride)( monitor );
+    stride_t const stride = NS(BeamMonitor_get_out_store_stride)( monitor );
 
     /* Currently, only consequentive attribte storage is implemented */
     SIXTRL_ASSERT( NS(BeamMonitor_are_attributes_continous)( monitor ) );
 
-    SIXTRL_ASSERT( NS(BeamMonitor_get_io_address)( monitor ) !=
+    SIXTRL_ASSERT( NS(BeamMonitor_get_out_address)( monitor ) !=
                   ( NS(be_monitor_addr_t) )0 );
     SIXTRL_ASSERT( stride > ( stride_t )0u );
     SIXTRL_ASSERT( store_idx < ( NS(buffer_size_t)
         )NS(BeamMonitor_get_num_stores)( monitor ) );
 
     return ( NS(buffer_addr_t ) )(
-            NS(BeamMonitor_get_io_address)( monitor ) + store_idx * stride );
+            NS(BeamMonitor_get_out_address)( monitor ) + store_idx * stride );
 }
 
 SIXTRL_INLINE int NS(Track_particle_beam_monitor)(
@@ -167,7 +167,7 @@ SIXTRL_INLINE int NS(Track_particle_beam_monitor)(
     SIXTRL_ASSERT( NS(Particles_get_state_value)(
         in_particles, particle_index ) == ( NS(particle_index_t) )1 );
 
-    if( ( NS(BeamMonitor_get_io_address)( monitor ) != ( addr_t )0 ) &&
+    if( ( NS(BeamMonitor_get_out_address)( monitor ) != ( addr_t )0 ) &&
         ( turn >= monitor_start ) )
     {
         nturn_t const store_idx =

--- a/sixtracklib/common/internal/CMakeLists.txt
+++ b/sixtracklib/common/internal/CMakeLists.txt
@@ -18,6 +18,7 @@ set( SIXTRL_COMMON_INTERNAL_C99_HEADERS
 
 set( SIXTRL_COMMON_INTERNAL_C99_SOURCES
     compute_arch.c
+    particles.c
 )
 
 add_library( sixtrack_common_internal OBJECT

--- a/sixtracklib/common/internal/particles.c
+++ b/sixtracklib/common/internal/particles.c
@@ -1,0 +1,251 @@
+#include "sixtracklib/common/definitions.h"
+#include "sixtracklib/common/internal/buffer_main_defines.h"
+#include "sixtracklib/common/buffer/buffer_object.h"
+#include "sixtracklib/common/particles.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sixtracklib/common/internal/buffer_main_defines.h"
+#include "sixtracklib/common/internal/particles_defines.h"
+
+static int NS(Particles_particle_id_recursive_merge_sort)(
+    NS(particle_index_t)* SIXTRL_RESTRICT particle_id_array,
+    NS(particle_index_t)* SIXTRL_RESTRICT lhs_temp_array,
+    NS(particle_index_t)* SIXTRL_RESTRICT rhs_temp_array,
+    NS(particle_num_elements_t) const left_index,
+    NS(particle_num_elements_t) const right_index );
+
+static int NS(Particles_particle_id_merge_and_check_for_duplicate)(
+    NS(particle_index_t)* SIXTRL_RESTRICT particle_id_array,
+    NS(particle_index_t)* SIXTRL_RESTRICT lhs_temp_array,
+    NS(particle_index_t)* SIXTRL_RESTRICT rhs_temp_array,
+    NS(particle_num_elements_t) const lhs_begin_index,
+    NS(particle_num_elements_t) const lhs_end_index,
+    NS(particle_num_elements_t) const rhs_end_index );
+
+extern SIXTRL_HOST_FN int NS(Particles_get_min_max_particle_id)(
+    SIXTRL_PARTICLE_ARGPTR_DEC const NS(Particles) *const SIXTRL_RESTRICT particles,
+    SIXTRL_ARGPTR_DEC NS(particle_num_elements_t)* SIXTRL_RESTRICT ptr_min_id,
+    SIXTRL_ARGPTR_DEC NS(particle_num_elements_t)* SIXTRL_RESTRICT ptr_max_id );
+
+/* ------------------------------------------------------------------------- */
+
+int NS(Particles_particle_id_merge_and_check_for_duplicate)(
+    NS(particle_index_t)* SIXTRL_RESTRICT particle_id_array,
+    NS(particle_index_t)* SIXTRL_RESTRICT lhs_temp_array,
+    NS(particle_index_t)* SIXTRL_RESTRICT rhs_temp_array,
+    NS(particle_num_elements_t) const lhs_begin_index,
+    NS(particle_num_elements_t) const lhs_end_index,
+    NS(particle_num_elements_t) const rhs_end_index )
+{
+    int success = 0;
+
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t jj = lhs_begin_index;
+    num_elem_t kk = lhs_begin_index;
+
+    num_elem_t const lhs_num = lhs_end_index - lhs_begin_index;
+    num_elem_t const rhs_num = rhs_end_index - lhs_end_index;
+
+    SIXTRL_ASSERT( lhs_temp_array    != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( rhs_temp_array    != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( particle_id_array != SIXTRL_NULLPTR );
+
+    SIXTRL_ASSERT( lhs_begin_index >= ( num_elem_t )0u );
+    SIXTRL_ASSERT( lhs_end_index   >= lhs_begin_index );
+    SIXTRL_ASSERT( rhs_end_index   >= lhs_end_index   );
+
+    for( ; jj < lhs_end_index ; ++jj, ++ii )
+    {
+        lhs_temp_array[ ii ] = particle_id_array[ jj ];
+    }
+
+    jj = lhs_end_index;
+    ii = ( num_elem_t )0u;
+
+    for(  ; jj < rhs_end_index ; ++jj, ++ii )
+    {
+        rhs_temp_array[ ii ] = particle_id_array[ jj ];
+    }
+
+    ii = ( num_elem_t )0u;
+    jj = ( num_elem_t )0u;
+
+    while( ( ii < lhs_num ) && ( jj < rhs_num ) )
+    {
+        if( lhs_temp_array[ ii ] < rhs_temp_array[ jj ] )
+        {
+            particle_id_array[ kk ] = lhs_temp_array[ ii ];
+            ++ii;
+        }
+        else if( lhs_temp_array[ ii ] > rhs_temp_array[ jj ] )
+        {
+            particle_id_array[ kk ] = rhs_temp_array[ jj ];
+            ++jj;
+        }
+        else
+        {
+            SIXTRL_ASSERT( lhs_temp_array[ ii ] == rhs_temp_array[ jj ] );
+            success = -1;
+            break;
+        }
+
+        ++kk;
+    };
+
+    if( ( success == 0 ) && ( ii < lhs_num ) )
+    {
+        while( ii < lhs_num )
+        {
+            particle_id_array[ kk++ ] = lhs_temp_array[ ii++ ];
+        };
+    }
+
+    if( ( success == 0 ) && ( jj < rhs_num ) )
+    {
+        while( jj < rhs_num )
+        {
+            particle_id_array[ kk++ ] = rhs_temp_array[ jj++ ];
+        };
+    }
+
+    return success;
+}
+
+int NS(Particles_particle_id_recursive_merge_sort)(
+    NS(particle_index_t)* SIXTRL_RESTRICT particle_id_array,
+    NS(particle_index_t)* SIXTRL_RESTRICT lhs_temp_array,
+    NS(particle_index_t)* SIXTRL_RESTRICT rhs_temp_array,
+    NS(particle_num_elements_t) const left_index,
+    NS(particle_num_elements_t) const right_index )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+
+    int success = -1;
+
+    SIXTRL_ASSERT( particle_id_array != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( lhs_temp_array    != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( rhs_temp_array    != SIXTRL_NULLPTR );
+
+    if( left_index < right_index )
+    {
+        num_elem_t const mid_index =
+            left_index + ( right_index - left_index ) / 2;
+
+        num_elem_t const mid_p1_index = mid_index + ( num_elem_t )1u;
+
+        if( ( 0 == NS(Particles_particle_id_recursive_merge_sort)(
+                particle_id_array, lhs_temp_array, rhs_temp_array,
+                left_index, mid_index ) ) &&
+            ( 0 == NS(Particles_particle_id_recursive_merge_sort)(
+                particle_id_array, lhs_temp_array, rhs_temp_array,
+                mid_p1_index, right_index ) ) )
+        {
+            success = NS(Particles_particle_id_merge_and_check_for_duplicate)(
+                particle_id_array, lhs_temp_array, rhs_temp_array,
+                left_index, mid_p1_index, right_index + ( num_elem_t )1u );
+        }
+    }
+    else if( left_index == right_index )
+    {
+        success = 0;
+    }
+
+
+    return success;
+}
+
+int NS(Particles_get_min_max_particle_id)(
+    SIXTRL_PARTICLE_ARGPTR_DEC const NS(Particles) *const SIXTRL_RESTRICT particles,
+    SIXTRL_ARGPTR_DEC NS(particle_num_elements_t)* SIXTRL_RESTRICT ptr_min_id,
+    SIXTRL_ARGPTR_DEC NS(particle_num_elements_t)* SIXTRL_RESTRICT ptr_max_id )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+    typedef NS(particle_index_t)        index_t;
+    typedef NS(buffer_size_t)           buf_size_t;
+
+    int success = -1;
+
+    buf_size_t const num_particles =
+        NS(Particles_get_num_of_particles)( particles );
+
+    if( num_particles > ( num_elem_t )0u )
+    {
+        buf_size_t const buffer_size = sizeof( num_elem_t ) * num_particles;
+
+        num_elem_t* particle_id_array = ( num_elem_t* )malloc( buffer_size );
+        num_elem_t* lhs_temp_array    = ( num_elem_t* )malloc( buffer_size );
+        num_elem_t* rhs_temp_array    = ( num_elem_t* )malloc( buffer_size );
+
+        if( ( buffer_size > ( buf_size_t )0u ) &&
+            ( particle_id_array != SIXTRL_NULLPTR ) &&
+            ( lhs_temp_array    != SIXTRL_NULLPTR ) &&
+            ( rhs_temp_array    != SIXTRL_NULLPTR ) )
+        {
+            num_elem_t ii = ( num_elem_t )0u;
+
+            for( ; ii < num_particles ; ++ii )
+            {
+                index_t const temp_particle_id =
+                    NS(Particles_get_particle_id_value)( particles, ii );
+
+                lhs_temp_array[ ii ]    = ( num_elem_t )0u;
+                rhs_temp_array[ ii ]    = ( num_elem_t )0u;
+                particle_id_array[ ii ] = ( temp_particle_id >= ( index_t )0u )
+                        ? ( num_elem_t )(  temp_particle_id )
+                        : ( num_elem_t )( -temp_particle_id );
+            }
+
+            success = NS(Particles_particle_id_recursive_merge_sort)(
+                particle_id_array, lhs_temp_array, rhs_temp_array,
+                ( num_elem_t )0u, num_particles - ( num_elem_t )1u );
+        }
+
+        #if !defined( NDEBUG )
+        if( success == 0 )
+        {
+            num_elem_t ii = ( num_elem_t )0u;
+            num_elem_t jj = ( num_elem_t )1u;
+
+            for( ; jj < num_particles ; ++ii, ++jj )
+            {
+                if( particle_id_array[ ii ] >= particle_id_array[ jj ] )
+                {
+                    success = -1;
+                    break;
+                }
+            }
+        }
+        #endif /* !defined( NDEBUG ) */
+
+        if( success == 0 )
+        {
+            if( ptr_max_id != SIXTRL_NULLPTR )
+            {
+                *ptr_max_id = particle_id_array[ num_particles - ( num_elem_t )1u ];
+            }
+
+            if( ptr_min_id != SIXTRL_NULLPTR )
+            {
+                *ptr_min_id = particle_id_array[ 0 ];
+            }
+        }
+
+        free( particle_id_array );
+        free( lhs_temp_array );
+        free( rhs_temp_array );
+
+        particle_id_array = SIXTRL_NULLPTR;
+        lhs_temp_array    = SIXTRL_NULLPTR;
+        rhs_temp_array    = SIXTRL_NULLPTR;
+    }
+
+    return success;
+}
+
+/* end: sixtracklib/common/internal/particles.c */

--- a/sixtracklib/common/particles.h
+++ b/sixtracklib/common/particles.h
@@ -187,6 +187,11 @@ NS(Particles_add_copy)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
     SIXTRL_PARTICLE_ARGPTR_DEC const NS(Particles) *const SIXTRL_RESTRICT p );
 
+SIXTRL_HOST_FN int NS(Particles_get_min_max_particle_id)(
+    SIXTRL_PARTICLE_ARGPTR_DEC const NS(Particles) *const SIXTRL_RESTRICT particles,
+    SIXTRL_ARGPTR_DEC NS(particle_num_elements_t)* SIXTRL_RESTRICT ptr_min_id,
+    SIXTRL_ARGPTR_DEC NS(particle_num_elements_t)* SIXTRL_RESTRICT ptr_max_id );
+
 #endif /* !defined( _GPUCODE ) */
 
 /* ------------------------------------------------------------------------- */
@@ -995,6 +1000,9 @@ SIXTRL_FN SIXTRL_STATIC void NS(Particles_set_particle_id_value)(
 SIXTRL_FN SIXTRL_STATIC void NS(Particles_assign_ptr_to_particle_id)(
     SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles,
     NS(particle_index_ptr_t) ptr_to_particle_ids );
+
+SIXTRL_FN SIXTRL_STATIC void NS(Particles_init_particle_ids)(
+    SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles );
 
 /* ------------------------------------------------------------------------- */
 
@@ -5111,6 +5119,25 @@ SIXTRL_INLINE void NS(Particles_assign_ptr_to_particle_id)(
 {
     SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
     particles->particle_id = ptr_to_particle_ids;
+    return;
+}
+
+SIXTRL_INLINE void NS(Particles_init_particle_ids)(
+    SIXTRL_PARTICLE_ARGPTR_DEC  NS(Particles)* SIXTRL_RESTRICT particles )
+{
+    typedef NS(particle_num_elements_t) num_elem_t;
+    typedef NS(particle_index_t)        index_t;
+
+    num_elem_t ii = ( num_elem_t )0u;
+    num_elem_t const num_particles = NS(Particles_get_num_of_particles)( particles );
+
+    SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
+
+    for( ; ii < num_particles ; ++ii )
+    {
+        NS(Particles_set_particle_id_value)( particles, ii, ( index_t )ii );
+    }
+
     return;
 }
 

--- a/sixtracklib/opencl/CMakeLists.txt
+++ b/sixtracklib/opencl/CMakeLists.txt
@@ -19,8 +19,8 @@ set( SIXTRACKLIB_OPENCL_KERNEL_SOURCES
      kernels/track_particles_debug.cl
      kernels/track_particles_optimized_priv_particles.cl
      kernels/track_particles_optimized_priv_particles_debug.cl
-     kernels/be_monitors_assign_io_buffer.cl
-     kernels/be_monitors_assign_io_buffer_debug.cl
+     kernels/be_monitors_assign_out_buffer.cl
+     kernels/be_monitors_assign_out_buffer_debug.cl
 )
 
 add_library( sixtrack_opencl OBJECT

--- a/sixtracklib/opencl/context.h
+++ b/sixtracklib/opencl/context.h
@@ -89,20 +89,20 @@ namespace SIXTRL_CXX_NAMESPACE
         bool setElementByElementTrackingKernelId(
             kernel_id_t const track_kernel_id );
 
-        int trackElementByElement( size_type io_particle_block_offset );
+        int trackElementByElement( size_type out_particle_block_offset );
 
-        int trackElementByElement( size_type io_particle_block_offset,
+        int trackElementByElement( size_type out_particle_block_offset,
                                    kernel_id_t const track_kernel_id );
 
         int trackElementByElement( ClArgument& SIXTRL_RESTRICT_REF particles_arg,
                                    ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
                                    ClArgument& SIXTRL_RESTRICT_REF elem_by_elem_buffer,
-                                   size_type io_particle_block_offset );
+                                   size_type out_particle_block_offset );
 
         int trackElementByElement( ClArgument& SIXTRL_RESTRICT_REF particles_arg,
                                    ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
                                    ClArgument& SIXTRL_RESTRICT_REF elem_by_elem_buffer,
-                                   size_type io_particle_block_offset,
+                                   size_type out_particle_block_offset,
                                    kernel_id_t const track_kernel_id );
 
         /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -114,15 +114,15 @@ namespace SIXTRL_CXX_NAMESPACE
 
         int assignBeamMonitorIoBuffer(
             ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
-            ClArgument& SIXTRL_RESTRICT_REF io_buffer_arg,
+            ClArgument& SIXTRL_RESTRICT_REF out_buffer_arg,
             size_type const num_particles,
-            size_type const io_particle_block_offset = size_type{ 0 } );
+            size_type const out_particle_block_offset = size_type{ 0 } );
 
         int assignBeamMonitorIoBuffer(
             ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
-            ClArgument& SIXTRL_RESTRICT_REF io_buffer_arg,
+            ClArgument& SIXTRL_RESTRICT_REF out_buffer_arg,
             size_type const num_particles,
-            size_type const io_particle_block_offset,
+            size_type const out_particle_block_offset,
             kernel_id_t const assign_kernel_id );
 
         /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -164,13 +164,13 @@ namespace SIXTRL_CXX_NAMESPACE
         program_id_t m_track_until_turn_program_id;
         program_id_t m_track_single_turn_program_id;
         program_id_t m_track_elem_by_elem_program_id;
-        program_id_t m_assign_be_mon_io_buffer_program_id;
+        program_id_t m_assign_be_mon_out_buffer_program_id;
         program_id_t m_clear_be_mon_program_id;
 
         kernel_id_t  m_track_until_turn_kernel_id;
         kernel_id_t  m_track_single_turn_kernel_id;
         kernel_id_t  m_track_elem_by_elem_kernel_id;
-        kernel_id_t  m_assign_be_mon_io_buffer_kernel_id;
+        kernel_id_t  m_assign_be_mon_out_buffer_kernel_id;
         kernel_id_t  m_clear_be_mon_kernel_id;
 
         bool         m_use_optimized_tracking;
@@ -282,11 +282,11 @@ SIXTRL_HOST_FN bool NS(ClContext_set_element_by_element_tracking_kernel_id)(
 
 SIXTRL_HOST_FN int NS(ClContext_continue_tracking_element_by_element)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
-    NS(buffer_size_t) const io_particle_block_offset );
+    NS(buffer_size_t) const out_particle_block_offset );
 
 SIXTRL_HOST_FN int NS(ClContext_continue_tracking_element_by_element_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
-    NS(buffer_size_t) const io_particle_block_offset,
+    NS(buffer_size_t) const out_particle_block_offset,
     int const kernel_id );
 
 SIXTRL_HOST_FN int NS(ClContext_track_element_by_element)(
@@ -294,62 +294,60 @@ SIXTRL_HOST_FN int NS(ClContext_track_element_by_element)(
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_elem_by_elem_buffer_arg,
-    NS(buffer_size_t) const io_particle_block_offset );
+    NS(buffer_size_t) const out_particle_block_offset );
 
 SIXTRL_HOST_FN int NS(ClContext_track_element_by_element_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_elem_by_elem_buffer_arg,
-    NS(buffer_size_t) const io_particle_block_offset,
+    NS(buffer_size_t) const out_particle_block_offset,
     int const tracking_kernel_id );
 
 /* ------------------------------------------------------------------------- */
 //
-SIXTRL_HOST_FN bool NS(ClContext_has_assign_beam_monitor_io_buffer_kernel)(
+SIXTRL_HOST_FN bool NS(ClContext_has_assign_beam_monitor_out_buffer_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN int NS(ClContext_get_assign_beam_monitor_io_buffer_kernel_id)(
+SIXTRL_HOST_FN int NS(ClContext_get_assign_beam_monitor_out_buffer_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN bool NS(ClContext_set_assign_beam_monitor_io_buffer_kernel_id)(
+SIXTRL_HOST_FN bool NS(ClContext_set_assign_beam_monitor_out_buffer_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const assign_kernel_id );
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_io_buffer)(
+SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg,
-    NS(ClArgument)* SIXTRL_RESTRICT io_buffer,
-    NS(buffer_size_t) const num_particles,
-    NS(buffer_size_t) const io_particle_block_offset );
+    NS(ClArgument)* SIXTRL_RESTRICT out_buffer,
+    NS(buffer_size_t) const out_particle_block_offset );
 
-SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_io_buffer_with_kernel_id)(
+SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer_with_kernel_id)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg,
-    NS(ClArgument)* SIXTRL_RESTRICT io_buffer,
-    NS(buffer_size_t) const num_particles,
-    NS(buffer_size_t) const io_particle_block_offset,
+    NS(ClArgument)* SIXTRL_RESTRICT out_buffer,
+    NS(buffer_size_t) const out_particle_block_offset,
     int const assign_kernel_id );
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN bool NS(ClContext_has_clear_beam_monitor_io_assignment_kernel)(
+SIXTRL_HOST_FN bool NS(ClContext_has_clear_beam_monitor_out_assignment_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN int NS(ClContext_get_clear_beam_monitor_io_assignment_kernel_id)(
+SIXTRL_HOST_FN int NS(ClContext_get_clear_beam_monitor_out_assignment_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN bool NS(ClContext_set_clear_beam_monitor_io_assignment_kernel_id)(
+SIXTRL_HOST_FN bool NS(ClContext_set_clear_beam_monitor_out_assignment_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const kernel_id );
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_io_assignment)(
+SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_out_assignment)(
     NS(ClContext)*  SIXTRL_RESTRICT context,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg );
 
-SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_io_assignment_with_kernel)(
+SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_out_assignment_with_kernel)(
     NS(ClContext)*  SIXTRL_RESTRICT context,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg,
     int const kernel_id );

--- a/sixtracklib/opencl/internal/context.cpp
+++ b/sixtracklib/opencl/internal/context.cpp
@@ -31,11 +31,11 @@ namespace SIXTRL_CXX_NAMESPACE
         m_track_until_turn_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_single_turn_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_elem_by_elem_program_id( ClContextBase::program_id_t{ -1 } ),
-        m_assign_be_mon_io_buffer_program_id( ClContextBase::program_id_t{ -1 } ),
+        m_assign_be_mon_out_buffer_program_id( ClContextBase::program_id_t{ -1 } ),
         m_clear_be_mon_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_single_turn_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_track_elem_by_elem_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
-        m_assign_be_mon_io_buffer_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
+        m_assign_be_mon_out_buffer_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_clear_be_mon_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_use_optimized_tracking( true ),
         m_enable_beam_beam( true )
@@ -48,11 +48,11 @@ namespace SIXTRL_CXX_NAMESPACE
         m_track_until_turn_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_single_turn_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_elem_by_elem_program_id( ClContextBase::program_id_t{ -1 } ),
-        m_assign_be_mon_io_buffer_program_id( ClContextBase::program_id_t{ -1 } ),
+        m_assign_be_mon_out_buffer_program_id( ClContextBase::program_id_t{ -1 } ),
         m_clear_be_mon_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_single_turn_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_track_elem_by_elem_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
-        m_assign_be_mon_io_buffer_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
+        m_assign_be_mon_out_buffer_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_clear_be_mon_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_use_optimized_tracking( true ),
         m_enable_beam_beam( true )
@@ -74,11 +74,11 @@ namespace SIXTRL_CXX_NAMESPACE
         m_track_until_turn_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_single_turn_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_elem_by_elem_program_id( ClContextBase::program_id_t{ -1 } ),
-        m_assign_be_mon_io_buffer_program_id( ClContextBase::program_id_t{ -1 } ),
+        m_assign_be_mon_out_buffer_program_id( ClContextBase::program_id_t{ -1 } ),
         m_clear_be_mon_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_single_turn_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_track_elem_by_elem_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
-        m_assign_be_mon_io_buffer_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
+        m_assign_be_mon_out_buffer_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_clear_be_mon_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_use_optimized_tracking( true ),
         m_enable_beam_beam( true )
@@ -105,11 +105,11 @@ namespace SIXTRL_CXX_NAMESPACE
         m_track_until_turn_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_single_turn_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_elem_by_elem_program_id( ClContextBase::program_id_t{ -1 } ),
-        m_assign_be_mon_io_buffer_program_id( ClContextBase::program_id_t{ -1 } ),
+        m_assign_be_mon_out_buffer_program_id( ClContextBase::program_id_t{ -1 } ),
         m_clear_be_mon_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_single_turn_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_track_elem_by_elem_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
-        m_assign_be_mon_io_buffer_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
+        m_assign_be_mon_out_buffer_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_clear_be_mon_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_use_optimized_tracking( true ),
         m_enable_beam_beam( true )
@@ -150,11 +150,11 @@ namespace SIXTRL_CXX_NAMESPACE
         m_track_until_turn_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_single_turn_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_elem_by_elem_program_id( ClContextBase::program_id_t{ -1 } ),
-        m_assign_be_mon_io_buffer_program_id( ClContextBase::program_id_t{ -1 } ),
+        m_assign_be_mon_out_buffer_program_id( ClContextBase::program_id_t{ -1 } ),
         m_clear_be_mon_program_id( ClContextBase::program_id_t{ -1 } ),
         m_track_single_turn_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_track_elem_by_elem_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
-        m_assign_be_mon_io_buffer_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
+        m_assign_be_mon_out_buffer_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_clear_be_mon_kernel_id( ClContextBase::kernel_id_t{ -1 } ),
         m_use_optimized_tracking( true ),
         m_enable_beam_beam( true )
@@ -504,21 +504,21 @@ namespace SIXTRL_CXX_NAMESPACE
     }
 
     int ClContext::trackElementByElement(
-        ClContext::size_type const io_particle_block_offset )
+        ClContext::size_type const out_particle_block_offset )
     {
         return ( this->hasElementByElementTrackingKernel() )
-            ? this->trackElementByElement( io_particle_block_offset,
+            ? this->trackElementByElement( out_particle_block_offset,
                 this->elementByElementTrackingKernelId() ) : -1;
     }
 
     int ClContext::trackElementByElement(
-        ClContext::size_type const io_particle_block_offset,
+        ClContext::size_type const out_particle_block_offset,
         ClContext::kernel_id_t const track_kernel_id )
     {
         if( this->hasElementByElementTrackingKernel() )
         {
             this->assignKernelArgumentValue(
-                track_kernel_id, 3u, io_particle_block_offset );
+                track_kernel_id, 3u, out_particle_block_offset );
 
             if( this->runKernel( track_kernel_id,
                 this->lastExecNumWorkItems( track_kernel_id ),
@@ -535,10 +535,10 @@ namespace SIXTRL_CXX_NAMESPACE
         ClArgument& SIXTRL_RESTRICT_REF particles_arg,
         ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
         ClArgument& SIXTRL_RESTRICT_REF elem_by_elem_buffer,
-        ClContext::size_type io_particle_block_offset )
+        ClContext::size_type out_particle_block_offset )
     {
         return this->trackElementByElement( particles_arg, beam_elements_arg,
-            elem_by_elem_buffer, io_particle_block_offset,
+            elem_by_elem_buffer, out_particle_block_offset,
                 this->elementByElementTrackingKernelId() );
     }
 
@@ -546,7 +546,7 @@ namespace SIXTRL_CXX_NAMESPACE
         ClArgument& SIXTRL_RESTRICT_REF particles_arg,
         ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
         ClArgument& SIXTRL_RESTRICT_REF elem_by_elem_buffer_arg,
-        ClContext::size_type io_particle_block_offset,
+        ClContext::size_type out_particle_block_offset,
         ClContext::kernel_id_t const track_kernel_id )
     {
         int success = -1;
@@ -581,7 +581,7 @@ namespace SIXTRL_CXX_NAMESPACE
         this->assignKernelArgument( track_kernel_id, 2u, elem_by_elem_buffer_arg );
 
         this->assignKernelArgumentValue(
-            track_kernel_id, 3u, io_particle_block_offset );
+            track_kernel_id, 3u, out_particle_block_offset );
 
         if( num_kernel_args > 4u )
         {
@@ -618,9 +618,9 @@ namespace SIXTRL_CXX_NAMESPACE
     bool ClContext::hasAssignBeamMonitorIoBufferKernel() const SIXTRL_NOEXCEPT
     {
         return ( ( this->hasSelectedNode() ) &&
-            ( this->m_assign_be_mon_io_buffer_kernel_id >= kernel_id_t{ 0 } ) &&
+            ( this->m_assign_be_mon_out_buffer_kernel_id >= kernel_id_t{ 0 } ) &&
             ( static_cast< size_type >(
-                this->m_assign_be_mon_io_buffer_kernel_id ) <
+                this->m_assign_be_mon_out_buffer_kernel_id ) <
                 this->numAvailableKernels() ) );
     }
 
@@ -628,7 +628,7 @@ namespace SIXTRL_CXX_NAMESPACE
     ClContext::assignBeamMonitorIoBufferKernelId() const SIXTRL_NOEXCEPT
     {
         return ( this->hasAssignBeamMonitorIoBufferKernel() )
-            ? this->m_assign_be_mon_io_buffer_kernel_id : kernel_id_t{ -1 };
+            ? this->m_assign_be_mon_out_buffer_kernel_id : kernel_id_t{ -1 };
     }
 
     bool ClContext::setAssignBeamMonitorIoBufferKernelId(
@@ -648,8 +648,8 @@ namespace SIXTRL_CXX_NAMESPACE
                 ( static_cast< size_type >( tracking_program_id ) <
                   this->numAvailablePrograms() ) )
             {
-                this->m_assign_be_mon_io_buffer_kernel_id  = track_kernel_id;
-                this->m_assign_be_mon_io_buffer_program_id = tracking_program_id;
+                this->m_assign_be_mon_out_buffer_kernel_id  = track_kernel_id;
+                this->m_assign_be_mon_out_buffer_program_id = tracking_program_id;
                 success = true;
             }
         }
@@ -659,9 +659,9 @@ namespace SIXTRL_CXX_NAMESPACE
 
     int ClContext::assignBeamMonitorIoBuffer(
         ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
-        ClArgument& SIXTRL_RESTRICT_REF io_buffer_arg,
+        ClArgument& SIXTRL_RESTRICT_REF out_buffer_arg,
         ClContext::size_type const num_particles,
-        ClContext::size_type const io_particle_block_offset  )
+        ClContext::size_type const out_particle_block_offset  )
     {
         int success = -1;
 
@@ -671,7 +671,7 @@ namespace SIXTRL_CXX_NAMESPACE
         if( ( kernel_id >= kernel_id_t{ 0 } ) && ( kernel_id <  max_kernel_id ) )
         {
             success = this->assignBeamMonitorIoBuffer( beam_elements_arg,
-                io_buffer_arg, num_particles, io_particle_block_offset, kernel_id );
+                out_buffer_arg, num_particles, out_particle_block_offset, kernel_id );
         }
 
         return success;
@@ -679,9 +679,9 @@ namespace SIXTRL_CXX_NAMESPACE
 
     int ClContext::assignBeamMonitorIoBuffer(
         ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
-        ClArgument& SIXTRL_RESTRICT_REF io_buffer_arg,
+        ClArgument& SIXTRL_RESTRICT_REF out_buffer_arg,
         ClContext::size_type const num_particles,
-        ClContext::size_type const io_particle_block_offset,
+        ClContext::size_type const out_particle_block_offset,
         ClContext::kernel_id_t const assign_kernel_id )
     {
         int success = -1;
@@ -695,24 +695,23 @@ namespace SIXTRL_CXX_NAMESPACE
         SIXTRL_ASSERT( !NS(Buffer_needs_remapping)(
             beam_elements_arg.ptrCObjectBuffer() ) );
 
-        SIXTRL_ASSERT( io_buffer_arg.usesCObjectBuffer() );
+        SIXTRL_ASSERT( out_buffer_arg.usesCObjectBuffer() );
         SIXTRL_ASSERT( !NS(Buffer_needs_remapping)(
-            io_buffer_arg.ptrCObjectBuffer() ) );
+            out_buffer_arg.ptrCObjectBuffer() ) );
 
         size_type const num_kernel_args = this->kernelNumArgs( assign_kernel_id );
-        SIXTRL_ASSERT(  num_kernel_args >= 4u );
+        SIXTRL_ASSERT(  num_kernel_args >= 3u );
 
         this->assignKernelArgument( assign_kernel_id, 0u, beam_elements_arg );
-        this->assignKernelArgument( assign_kernel_id, 1u, io_buffer_arg );
-        this->assignKernelArgumentValue( assign_kernel_id, 2u, num_particles );
+        this->assignKernelArgument( assign_kernel_id, 1u, out_buffer_arg );
 
         this->assignKernelArgumentValue(
-            assign_kernel_id, 3u, io_particle_block_offset );
+            assign_kernel_id, 2u, out_particle_block_offset );
 
-        if( num_kernel_args > 4u )
+        if( num_kernel_args > 3u )
         {
             this->assignKernelArgumentClBuffer(
-                assign_kernel_id, 4u, this->internalSuccessFlagBuffer() );
+                assign_kernel_id, 3u, this->internalSuccessFlagBuffer() );
         }
 
         success = ( this->runKernel( assign_kernel_id,
@@ -939,7 +938,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
         std::string path_to_particles_track_prog     = path_to_kernel_dir;
         std::string path_to_particles_track_opt_prog = path_to_kernel_dir;
-        std::string path_to_assign_io_buffer_prog    = path_to_kernel_dir;
+        std::string path_to_assign_out_buffer_prog    = path_to_kernel_dir;
 
         if( !this->debugMode() )
         {
@@ -949,8 +948,8 @@ namespace SIXTRL_CXX_NAMESPACE
             path_to_particles_track_opt_prog +=
                 "track_particles_optimized_priv_particles.cl";
 
-            path_to_assign_io_buffer_prog    +=
-                "be_monitors_assign_io_buffer.cl";
+            path_to_assign_out_buffer_prog    +=
+                "be_monitors_assign_out_buffer.cl";
         }
         else
         {
@@ -960,8 +959,8 @@ namespace SIXTRL_CXX_NAMESPACE
             path_to_particles_track_opt_prog +=
                 "track_particles_optimized_priv_particles_debug.cl";
 
-            path_to_assign_io_buffer_prog    +=
-                "be_monitors_assign_io_buffer_debug.cl";
+            path_to_assign_out_buffer_prog    +=
+                "be_monitors_assign_out_buffer_debug.cl";
         }
 
         std::string track_compile_options = "-D_GPUCODE=1";
@@ -992,13 +991,13 @@ namespace SIXTRL_CXX_NAMESPACE
         track_optimized_compile_options += " -I";
         track_optimized_compile_options += NS(PATH_TO_SIXTRL_INCLUDE_DIR);
 
-        std::string assign_io_buffer_compile_options = " -D_GPUCODE=1";
-        assign_io_buffer_compile_options += " -DSIXTRL_BUFFER_ARGPTR_DEC=__private";
-        assign_io_buffer_compile_options += " -DSIXTRL_BUFFER_DATAPTR_DEC=__global";
-        assign_io_buffer_compile_options += " -DSIXTRL_PARTICLE_ARGPTR_DEC=__global";
-        assign_io_buffer_compile_options += " -DSIXTRL_PARTICLE_DATAPTR_DEC=__global";
-        assign_io_buffer_compile_options += " -I";
-        assign_io_buffer_compile_options += NS(PATH_TO_SIXTRL_INCLUDE_DIR);
+        std::string assign_out_buffer_compile_options = " -D_GPUCODE=1";
+        assign_out_buffer_compile_options += " -DSIXTRL_BUFFER_ARGPTR_DEC=__private";
+        assign_out_buffer_compile_options += " -DSIXTRL_BUFFER_DATAPTR_DEC=__global";
+        assign_out_buffer_compile_options += " -DSIXTRL_PARTICLE_ARGPTR_DEC=__global";
+        assign_out_buffer_compile_options += " -DSIXTRL_PARTICLE_DATAPTR_DEC=__global";
+        assign_out_buffer_compile_options += " -I";
+        assign_out_buffer_compile_options += NS(PATH_TO_SIXTRL_INCLUDE_DIR);
 
         program_id_t const track_program_id = this->addProgramFile(
             path_to_particles_track_prog, track_compile_options );
@@ -1006,12 +1005,12 @@ namespace SIXTRL_CXX_NAMESPACE
         program_id_t const track_optimized_program_id = this->addProgramFile(
             path_to_particles_track_opt_prog, track_optimized_compile_options );
 
-        program_id_t const io_buffer_program_id = this->addProgramFile(
-            path_to_assign_io_buffer_prog, assign_io_buffer_compile_options );
+        program_id_t const out_buffer_program_id = this->addProgramFile(
+            path_to_assign_out_buffer_prog, assign_out_buffer_compile_options );
 
         if( ( track_program_id            >= program_id_t{ 0 } ) &&
             ( track_optimized_program_id  >= program_id_t{ 0 } ) &&
-            ( io_buffer_program_id        >= program_id_t{ 0 } ) )
+            ( out_buffer_program_id        >= program_id_t{ 0 } ) )
         {
             if( !this->useOptimizedTrackingByDefault() )
             {
@@ -1026,8 +1025,8 @@ namespace SIXTRL_CXX_NAMESPACE
                 this->m_track_elem_by_elem_program_id = track_optimized_program_id;
             }
 
-            this->m_assign_be_mon_io_buffer_program_id = io_buffer_program_id;
-            this->m_clear_be_mon_program_id            = io_buffer_program_id;
+            this->m_assign_be_mon_out_buffer_program_id = out_buffer_program_id;
+            this->m_clear_be_mon_program_id            = out_buffer_program_id;
 
             success = true;
         }
@@ -1128,11 +1127,11 @@ namespace SIXTRL_CXX_NAMESPACE
             }
 
             if( ( success ) &&
-                ( this->m_assign_be_mon_io_buffer_program_id >= program_id_t{ 0 } ) &&
-                ( this->m_assign_be_mon_io_buffer_program_id <  max_program_id ) )
+                ( this->m_assign_be_mon_out_buffer_program_id >= program_id_t{ 0 } ) &&
+                ( this->m_assign_be_mon_out_buffer_program_id <  max_program_id ) )
             {
                 std::string kernel_name( SIXTRL_C99_NAMESPACE_PREFIX_STR );
-                kernel_name += "BeamMonitor_assign_io_buffer_from_offset";
+                kernel_name += "BeamMonitor_assign_out_buffer_from_offset";
 
                 if( this->debugMode() )
                 {
@@ -1142,7 +1141,7 @@ namespace SIXTRL_CXX_NAMESPACE
                 kernel_name += "_opencl";
 
                 kernel_id_t const kernel_id = this->enableKernel(
-                    kernel_name.c_str(), this->m_assign_be_mon_io_buffer_program_id );
+                    kernel_name.c_str(), this->m_assign_be_mon_out_buffer_program_id );
 
                 if( kernel_id >= kernel_id_t{ 0 } )
                 {
@@ -1349,20 +1348,20 @@ SIXTRL_HOST_FN bool NS(ClContext_set_element_by_element_tracking_kernel_id)(
 
 SIXTRL_HOST_FN int NS(ClContext_continue_tracking_element_by_element)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
-    NS(buffer_size_t) const io_particle_block_offset )
+    NS(buffer_size_t) const out_particle_block_offset )
 {
     return ( ctx != nullptr )
-        ? ctx->trackElementByElement( io_particle_block_offset )
+        ? ctx->trackElementByElement( out_particle_block_offset )
         : -1;
 }
 
 SIXTRL_HOST_FN int NS(ClContext_continue_tracking_element_by_element_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
-    NS(buffer_size_t) const io_particle_block_offset,
+    NS(buffer_size_t) const out_particle_block_offset,
     int const kernel_id )
 {
     return ( ctx != nullptr )
-        ? ctx->trackElementByElement( io_particle_block_offset, kernel_id )
+        ? ctx->trackElementByElement( out_particle_block_offset, kernel_id )
         : -1;
 }
 
@@ -1371,14 +1370,14 @@ SIXTRL_HOST_FN int NS(ClContext_track_element_by_element)(
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_elem_by_elem_buffer_arg,
-    NS(buffer_size_t) const io_particle_block_offset )
+    NS(buffer_size_t) const out_particle_block_offset )
 {
     return ( ( ctx != nullptr ) && ( ptr_particles_arg != nullptr ) &&
              ( ptr_beam_elements_arg != nullptr ) &&
              ( ptr_elem_by_elem_buffer_arg != nullptr ) )
         ? ctx->trackElementByElement( *ptr_particles_arg, *ptr_beam_elements_arg,
                                       *ptr_elem_by_elem_buffer_arg,
-                                      io_particle_block_offset )
+                                      out_particle_block_offset )
         : -1;
 }
 
@@ -1387,7 +1386,7 @@ SIXTRL_HOST_FN int NS(ClContext_track_element_by_element_with_kernel_id)(
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_elem_by_elem_buffer_arg,
-    NS(buffer_size_t) const io_particle_block_offset,
+    NS(buffer_size_t) const out_particle_block_offset,
     int const tracking_kernel_id )
 {
     return ( ( ctx != nullptr ) && ( ptr_particles_arg != nullptr ) &&
@@ -1395,25 +1394,25 @@ SIXTRL_HOST_FN int NS(ClContext_track_element_by_element_with_kernel_id)(
              ( ptr_elem_by_elem_buffer_arg != nullptr ) )
         ? ctx->trackElementByElement( *ptr_particles_arg, *ptr_beam_elements_arg,
                                       *ptr_elem_by_elem_buffer_arg,
-                                      io_particle_block_offset, tracking_kernel_id )
+                                      out_particle_block_offset, tracking_kernel_id )
         : -1;
 }
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN bool NS(ClContext_has_assign_beam_monitor_io_buffer_kernel)(
+SIXTRL_HOST_FN bool NS(ClContext_has_assign_beam_monitor_out_buffer_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return (ctx != nullptr ) ? ctx->hasAssignBeamMonitorIoBufferKernel() : false;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_get_assign_beam_monitor_io_buffer_kernel_id)(
+SIXTRL_HOST_FN int NS(ClContext_get_assign_beam_monitor_out_buffer_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr ) ? ctx->assignBeamMonitorIoBufferKernelId() : -1;
 }
 
-SIXTRL_HOST_FN bool NS(ClContext_set_assign_beam_monitor_io_buffer_kernel_id)(
+SIXTRL_HOST_FN bool NS(ClContext_set_assign_beam_monitor_out_buffer_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const assign_kernel_id )
 {
     return ( ctx != nullptr )
@@ -1423,38 +1422,35 @@ SIXTRL_HOST_FN bool NS(ClContext_set_assign_beam_monitor_io_buffer_kernel_id)(
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_io_buffer)(
+SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
-    NS(ClArgument)* SIXTRL_RESTRICT ptr_io_buffer_arg,
-    NS(buffer_size_t) const num_particles,
-    NS(buffer_size_t) const io_particle_block_offset )
+    NS(ClArgument)* SIXTRL_RESTRICT ptr_out_buffer_arg,
+    NS(buffer_size_t) const out_particle_block_offset )
 {
     return ( ( ctx != nullptr ) && ( ptr_beam_elements_arg != nullptr ) &&
-             ( ptr_io_buffer_arg != nullptr ) )
+             ( ptr_out_buffer_arg != nullptr ) )
         ? ctx->assignBeamMonitorIoBuffer(
-            *ptr_beam_elements_arg, *ptr_io_buffer_arg,
-            num_particles, io_particle_block_offset )
+            *ptr_beam_elements_arg, *ptr_out_buffer_arg, out_particle_block_offset )
         : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_io_buffer_with_kernel_id)(
+SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer_with_kernel_id)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
-    NS(ClArgument)* SIXTRL_RESTRICT ptr_io_buffer_arg,
-    NS(buffer_size_t) const num_particles,
-    NS(buffer_size_t) const io_particle_block_offset,
+    NS(ClArgument)* SIXTRL_RESTRICT ptr_out_buffer_arg,
+    NS(buffer_size_t) const out_particle_block_offset,
     int const assign_kernel_id )
 {
     return ( ( ctx != nullptr ) && ( ptr_beam_elements_arg != nullptr ) &&
-             ( ptr_io_buffer_arg != nullptr ) )
+             ( ptr_out_buffer_arg != nullptr ) )
         ? ctx->assignBeamMonitorIoBuffer(
-            *ptr_beam_elements_arg, *ptr_io_buffer_arg,
-            num_particles, io_particle_block_offset, assign_kernel_id )
+            *ptr_beam_elements_arg, *ptr_out_buffer_arg,
+            out_particle_block_offset, assign_kernel_id )
         : -1;
 }
 
-SIXTRL_HOST_FN bool NS(ClContext_has_clear_beam_monitor_io_assignment_kernel)(
+SIXTRL_HOST_FN bool NS(ClContext_has_clear_beam_monitor_out_assignment_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr )
@@ -1462,14 +1458,14 @@ SIXTRL_HOST_FN bool NS(ClContext_has_clear_beam_monitor_io_assignment_kernel)(
         : false;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_get_clear_beam_monitor_io_assignment_kernel_id)(
+SIXTRL_HOST_FN int NS(ClContext_get_clear_beam_monitor_out_assignment_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return (ctx != nullptr )
         ? ctx->clearBeamMonitorIoBufferAssignmentKernelId() : -1;
 }
 
-SIXTRL_HOST_FN bool NS(ClContext_set_clear_beam_monitor_io_assignment_kernel_id)(
+SIXTRL_HOST_FN bool NS(ClContext_set_clear_beam_monitor_out_assignment_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const kernel_id )
 {
     bool success = false;
@@ -1484,7 +1480,7 @@ SIXTRL_HOST_FN bool NS(ClContext_set_clear_beam_monitor_io_assignment_kernel_id)
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_io_assignment)(
+SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_out_assignment)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg )
 {
@@ -1493,7 +1489,7 @@ SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_io_assignment)(
         : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_io_assignment_with_kernel)(
+SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_out_assignment_with_kernel)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg,
     int const kernel_id )

--- a/sixtracklib/opencl/kernels/be_monitors_assign_out_buffer.cl
+++ b/sixtracklib/opencl/kernels/be_monitors_assign_out_buffer.cl
@@ -34,7 +34,7 @@ __kernel void NS(BeamMonitor_assign_out_buffer_from_offset_opencl)(
     size_t const global_size = get_global_size( 0 );
     size_t const gid_to_assign_out_buffer = ( size_t )0u;
 
-    if( global_id == gid_to_assign_io_buffer )
+    if( global_id == gid_to_assign_out_buffer )
     {
         buf_size_t const slot_size = ( buf_size_t )8u;
 

--- a/sixtracklib/opencl/kernels/be_monitors_assign_out_buffer.cl
+++ b/sixtracklib/opencl/kernels/be_monitors_assign_out_buffer.cl
@@ -1,5 +1,5 @@
-#ifndef SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_IO_BUFFER_CL__
-#define SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_IO_BUFFER_CL__
+#ifndef SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_OUT_BUFFER_CL__
+#define SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_OUT_BUFFER_CL__
 
 #if !defined( SIXTRL_NO_INCLUDES )
     #include "sixtracklib/opencl/internal/default_compile_options.h"
@@ -10,31 +10,29 @@
     #include "sixtracklib/common/internal/particles_defines.h"
     #include "sixtracklib/common/particles.h"
     #include "sixtracklib/common/be_monitor/be_monitor.h"
-    #include "sixtracklib/common/be_monitor/io_buffer.h"
+    #include "sixtracklib/common/be_monitor/output_buffer.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
-__kernel void NS(BeamMonitor_assign_io_buffer_from_offset_opencl)(
+__kernel void NS(BeamMonitor_assign_out_buffer_from_offset_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT beam_elements_buf,
-    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT io_buffer,
-    SIXTRL_UINT64_T const num_particles,
-    SIXTRL_UINT64_T const io_particles_block_offset );
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT out_buffer,
+    SIXTRL_UINT64_T const out_particles_block_offset );
 
 __kernel void NS(BeamMonitor_clear_all_line_obj_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT beam_elements_buf );
 
 /* ========================================================================= */
 
-__kernel void NS(BeamMonitor_assign_io_buffer_from_offset_opencl)(
+__kernel void NS(BeamMonitor_assign_out_buffer_from_offset_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT beam_elements_buf,
-    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT io_buffer,
-    SIXTRL_UINT64_T const num_particles,
-    SIXTRL_UINT64_T const io_particles_block_offset )
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT out_buffer,
+    SIXTRL_UINT64_T const out_particles_block_offset )
 {
     typedef NS(buffer_size_t) buf_size_t;
 
-    size_t const global_id               = get_global_id( 0 );
-    size_t const global_size             = get_global_size( 0 );
-    size_t const gid_to_assign_io_buffer = ( size_t )0u;
+    size_t const global_id   = get_global_id( 0 );
+    size_t const global_size = get_global_size( 0 );
+    size_t const gid_to_assign_out_buffer = ( size_t )0u;
 
     if( global_id == gid_to_assign_io_buffer )
     {
@@ -44,11 +42,10 @@ __kernel void NS(BeamMonitor_assign_io_buffer_from_offset_opencl)(
             beam_elements_buf, slot_size ) );
 
         SIXTRL_ASSERT( !NS(ManagedBuffer_needs_remapping)(
-            io_buffer, slot_size ) );
+            out_buffer, slot_size ) );
 
-        NS(BeamMonitor_assign_managed_io_buffer)(
-            beam_elements_buf, io_buffer, num_particles,
-                io_particles_block_offset, slot_size );
+        NS(BeamMonitor_assign_managed_particles_out_buffer)(
+            beam_elements_buf, out_buffer, out_particles_block_offset, slot_size );
     }
 
     return;
@@ -100,6 +97,6 @@ __kernel void NS(BeamMonitor_clear_all_line_obj_opencl)(
     return;
 }
 
-#endif /* SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_IO_BUFFER_CL__ */
+#endif /* SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_OUT_BUFFER_CL__ */
 
-/* end: sixtracklib/opencl/kernels/be_monitors_assign_io_buffer.cl */
+/* end: sixtracklib/opencl/kernels/be_monitors_assign_out_buffer.cl */

--- a/sixtracklib/opencl/kernels/be_monitors_assign_out_buffer_debug.cl
+++ b/sixtracklib/opencl/kernels/be_monitors_assign_out_buffer_debug.cl
@@ -38,8 +38,7 @@ __kernel void NS(BeamMonitor_assign_out_buffer_from_offset_debug_opencl)(
 
     SIXTRL_INT32_T success_flag = ( SIXTRL_INT32_T )-1;
 
-    if( ( num_particles > ( SIXTRL_UINT64_T )0u ) &&
-        ( !NS(ManagedBuffer_needs_remapping)( beam_elements_buf, slot_size ) ) &&
+    if( ( !NS(ManagedBuffer_needs_remapping)( beam_elements_buf, slot_size ) ) &&
         ( !NS(ManagedBuffer_needs_remapping)( out_buffer, slot_size ) ) &&
         (  NS(ManagedBuffer_get_num_objects)( out_buffer, slot_size ) >=
             out_particles_block_offset ) )
@@ -51,7 +50,7 @@ __kernel void NS(BeamMonitor_assign_out_buffer_from_offset_debug_opencl)(
 
         if( global_id == gid_to_assign_out_buffer )
         {
-            success_flag = NS(BeamMonitor_assign_managed_out_buffer)(
+            success_flag = NS(BeamMonitor_assign_managed_particles_out_buffer)(
                 beam_elements_buf, out_buffer, out_particles_block_offset, slot_size );
         }
     }

--- a/sixtracklib/opencl/kernels/be_monitors_assign_out_buffer_debug.cl
+++ b/sixtracklib/opencl/kernels/be_monitors_assign_out_buffer_debug.cl
@@ -1,5 +1,5 @@
-#ifndef SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_IO_BUFFER_DEBUG_KERNEL_CL__
-#define SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_IO_BUFFER_DEBUG_KERNEL_CL__
+#ifndef SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_OUT_BUFFER_DEBUG_KERNEL_CL__
+#define SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_OUT_BUFFER_DEBUG_KERNEL_CL__
 
 #if !defined( SIXTRL_NO_INCLUDES )
     #include "sixtracklib/opencl/internal/default_compile_options.h"
@@ -10,16 +10,15 @@
     #include "sixtracklib/common/internal/particles_defines.h"
     #include "sixtracklib/common/particles.h"
     #include "sixtracklib/common/be_monitor/be_monitor.h"
-    #include "sixtracklib/common/be_monitor/io_buffer.h"
+    #include "sixtracklib/common/be_monitor/output_buffer.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
 #pragma OPENCL_EXTENSION cl_khr_int32_extended_atomics
 
-__kernel void NS(BeamMonitor_assign_io_buffer_from_offset_debug_opencl)(
+__kernel void NS(BeamMonitor_assign_out_buffer_from_offset_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT beam_elements_buf,
-    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT io_buffer,
-    SIXTRL_UINT64_T const num_particles,
-    SIXTRL_UINT64_T const io_particles_block_offset,
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT out_buffer,
+    SIXTRL_UINT64_T const out_particles_block_offset,
     SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T* SIXTRL_RESTRICT ptr_success_flag );
 
 __kernel void NS(BeamMonitor_clear_all_line_obj_debug_opencl)(
@@ -28,11 +27,10 @@ __kernel void NS(BeamMonitor_clear_all_line_obj_debug_opencl)(
 
 /* ========================================================================= */
 
-__kernel void NS(BeamMonitor_assign_io_buffer_from_offset_debug_opencl)(
+__kernel void NS(BeamMonitor_assign_out_buffer_from_offset_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT beam_elements_buf,
-    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT io_buffer,
-    SIXTRL_UINT64_T const num_particles,
-    SIXTRL_UINT64_T const io_particles_block_offset,
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT out_buffer,
+    SIXTRL_UINT64_T const out_particles_block_offset,
     SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T* SIXTRL_RESTRICT ptr_success_flag )
 {
     typedef NS(buffer_size_t) buf_size_t;
@@ -42,20 +40,19 @@ __kernel void NS(BeamMonitor_assign_io_buffer_from_offset_debug_opencl)(
 
     if( ( num_particles > ( SIXTRL_UINT64_T )0u ) &&
         ( !NS(ManagedBuffer_needs_remapping)( beam_elements_buf, slot_size ) ) &&
-        ( !NS(ManagedBuffer_needs_remapping)( io_buffer, slot_size ) ) &&
-        (  NS(ManagedBuffer_get_num_objects)( io_buffer, slot_size ) >=
-            io_particles_block_offset ) )
+        ( !NS(ManagedBuffer_needs_remapping)( out_buffer, slot_size ) ) &&
+        (  NS(ManagedBuffer_get_num_objects)( out_buffer, slot_size ) >=
+            out_particles_block_offset ) )
     {
-        size_t const gid_to_assign_io_buffer = ( size_t )0u;
+        size_t const gid_to_assign_out_buffer = ( size_t )0u;
         size_t const global_id = get_global_id( 0 );
 
         success_flag = ( SIXTRL_INT32_T )0u;
 
-        if( global_id == gid_to_assign_io_buffer )
+        if( global_id == gid_to_assign_out_buffer )
         {
-            success_flag = NS(BeamMonitor_assign_managed_io_buffer)(
-                beam_elements_buf, io_buffer, num_particles,
-                    io_particles_block_offset, slot_size );
+            success_flag = NS(BeamMonitor_assign_managed_out_buffer)(
+                beam_elements_buf, out_buffer, out_particles_block_offset, slot_size );
         }
     }
 
@@ -132,6 +129,6 @@ __kernel void NS(BeamMonitor_clear_all_line_obj_debug_opencl)(
     return;
 }
 
-#endif /* SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_IO_BUFFER_DEBUG_KERNEL_CL__ */
+#endif /* SIXTRACKLIB_OPENCL_KERNELS_BE_MONITORS_ASSIGN_OUT_BUFFER_DEBUG_KERNEL_CL__ */
 
-/* end: sixtracklib/opencl/kernels/be_monitors_assign_io_buffer_debug.cl */
+/* end: sixtracklib/opencl/kernels/be_monitors_assign_out_buffer_debug.cl */

--- a/sixtracklib/opencl/kernels/track_particles.cl
+++ b/sixtracklib/opencl/kernels/track_particles.cl
@@ -25,7 +25,7 @@ __kernel void NS(Track_particles_elem_by_elem_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT elem_by_elem_buf,
-    SIXTRL_UINT64_T const io_particle_blocks_offset );
+    SIXTRL_UINT64_T const out_particle_blocks_offset );
 
 /* ========================================================================= */
 
@@ -142,7 +142,7 @@ __kernel void NS(Track_particles_elem_by_elem_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT elem_by_elem_buf,
-    SIXTRL_UINT64_T const io_particle_blocks_offset )
+    SIXTRL_UINT64_T const out_particle_blocks_offset )
 {
     typedef NS(buffer_size_t)                                buf_size_t;
     typedef NS(particle_num_elements_t)                      num_element_t;
@@ -165,7 +165,7 @@ __kernel void NS(Track_particles_elem_by_elem_opencl)(
     ptr_particles_t particles = NS(Particles_managed_buffer_get_particles)(
         particles_buf, 0u, slot_size );
 
-    obj_iter_t io_obj_begin = NS(ManagedBuffer_get_objects_index_begin)(
+    obj_iter_t out_obj_begin = NS(ManagedBuffer_get_objects_index_begin)(
         elem_by_elem_buf, slot_size );
 
     num_element_t const num_particles =
@@ -177,7 +177,7 @@ __kernel void NS(Track_particles_elem_by_elem_opencl)(
 
     SIXTRL_ASSERT( be_begin     != SIXTRL_NULLPTR );
     SIXTRL_ASSERT( be_end       != SIXTRL_NULLPTR );
-    SIXTRL_ASSERT( io_obj_begin != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( out_obj_begin != SIXTRL_NULLPTR );
 
     SIXTRL_ASSERT( NS(ManagedBuffer_get_num_objects)(
         particles_buffer, slot_size ) == ( buf_size_t )1u );
@@ -186,7 +186,7 @@ __kernel void NS(Track_particles_elem_by_elem_opencl)(
         belem_buf, slot_size ) > ( buf_size_t )0u );
 
     SIXTRL_ASSERT( NS(ManagedBuffer_get_num_objects)( elem_by_elem_buf ) >=
-        ( io_particle_blocks_offset + NS(ManagedBuffer_get_num_objects)(
+        ( out_particle_blocks_offset + NS(ManagedBuffer_get_num_objects)(
             belem_buf, slot_size ) ) );
 
     SIXTRL_ASSERT( NS(Particles_managed_buffer_is_particles_buffer)(
@@ -197,22 +197,22 @@ __kernel void NS(Track_particles_elem_by_elem_opencl)(
 
     SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
 
-    io_obj_begin = io_obj_begin + io_particle_blocks_offset;
+    out_obj_begin = out_obj_begin + out_particle_blocks_offset;
 
     for( ; particle_id < num_particles ; particle_id += stride )
     {
-        obj_iter_t    io_obj_it = io_obj_begin;
+        obj_iter_t    out_obj_it = out_obj_begin;
         obj_const_iter_t  be_it = be_begin;
 
         index_t beam_element_id = NS(Particles_get_at_element_id_value)(
             particles, particle_id );
 
-        for( ; be_it != be_end ; ++be_it, ++io_obj_it )
+        for( ; be_it != be_end ; ++be_it, ++out_obj_it )
         {
-            ptr_particles_t io_particles =
-                NS(BufferIndex_get_particles)( io_obj_it );
+            ptr_particles_t out_particles =
+                NS(BufferIndex_get_particles)( out_obj_it );
 
-            NS(Particles_copy_single)( io_particles, particle_id,
+            NS(Particles_copy_single)( out_particles, particle_id,
                                        particles, particle_id );
 
             if( 0 != NS(Track_particle_beam_element_obj)(

--- a/sixtracklib/opencl/kernels/track_particles_debug.cl
+++ b/sixtracklib/opencl/kernels/track_particles_debug.cl
@@ -29,7 +29,7 @@ __kernel void NS(Track_particles_elem_by_elem_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT elem_by_elem_buf,
-    SIXTRL_UINT64_T const io_particle_blocks_offset,
+    SIXTRL_UINT64_T const out_particle_blocks_offset,
     SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T* SIXTRL_RESTRICT ptr_success_flag );
 
 /* ========================================================================= */
@@ -168,7 +168,7 @@ __kernel void NS(Track_particles_elem_by_elem_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT elem_by_elem_buf,
-    SIXTRL_UINT64_T const io_particle_blocks_offset,
+    SIXTRL_UINT64_T const out_particle_blocks_offset,
     SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T* SIXTRL_RESTRICT ptr_success_flag )
 {
     typedef NS(buffer_size_t)                                buf_size_t;
@@ -189,7 +189,7 @@ __kernel void NS(Track_particles_elem_by_elem_debug_opencl)(
                 particles_buf, slot_size ) == ( buf_size_t )1u ) &&
         ( !NS(ManagedBuffer_needs_remapping)( belem_buf, slot_size ) ) &&
         ( ( NS(ManagedBuffer_get_num_objects)( belem_buf, slot_size ) +
-            io_particle_blocks_offset ) <= NS(ManagedBuffer_get_num_objects)(
+            out_particle_blocks_offset ) <= NS(ManagedBuffer_get_num_objects)(
                 elem_by_elem_buf, slot_size ) ) )
     {
         buf_size_t const slot_size = ( buf_size_t )8u;
@@ -206,7 +206,7 @@ __kernel void NS(Track_particles_elem_by_elem_debug_opencl)(
         ptr_particles_t particles = NS(Particles_managed_buffer_get_particles)(
         particles_buf, 0u, slot_size );
 
-        obj_iter_t io_obj_begin = NS(ManagedBuffer_get_objects_index_begin)(
+        obj_iter_t out_obj_begin = NS(ManagedBuffer_get_objects_index_begin)(
             elem_by_elem_buf, slot_size );
 
         num_element_t const num_particles =
@@ -214,7 +214,7 @@ __kernel void NS(Track_particles_elem_by_elem_debug_opencl)(
 
         SIXTRL_ASSERT( be_begin     != SIXTRL_NULLPTR );
         SIXTRL_ASSERT( be_end       != SIXTRL_NULLPTR );
-        SIXTRL_ASSERT( io_obj_begin != SIXTRL_NULLPTR );
+        SIXTRL_ASSERT( out_obj_begin != SIXTRL_NULLPTR );
 
         SIXTRL_ASSERT( NS(Particles_managed_buffer_is_particles_buffer)(
             elem_by_elem_buf, slot_size ) );
@@ -230,32 +230,32 @@ __kernel void NS(Track_particles_elem_by_elem_debug_opencl)(
 
         SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );
 
-        io_obj_begin = io_obj_begin + io_particle_blocks_offset;
+        out_obj_begin = out_obj_begin + out_particle_blocks_offset;
 
-        SIXTRL_ASSERT( NS(Object_get_type_id)( io_obj_begin ) ==
+        SIXTRL_ASSERT( NS(Object_get_type_id)( out_obj_begin ) ==
                        NS(OBJECT_TYPE_PARTICLE) );
 
-        SIXTRL_ASSERT( NS(Object_get_begin_addr)( io_obj_begin ) != 0u );
+        SIXTRL_ASSERT( NS(Object_get_begin_addr)( out_obj_begin ) != 0u );
         SIXTRL_ASSERT( NS(Particles_get_num_of_particles)(
             ( ptr_particles_t )( uintptr_t )NS(Object_get_begin_addr)(
-                io_obj_begin ) ) >= num_particles );
+                out_obj_begin ) ) >= num_particles );
 
         success_flag = ( SIXTRL_INT32_T )0u;
 
         for( ; particle_id < num_particles ; particle_id += stride )
         {
-            obj_iter_t    io_obj_it = io_obj_begin;
+            obj_iter_t    out_obj_it = out_obj_begin;
             obj_const_iter_t  be_it = be_begin;
 
             index_t beam_element_id = NS(Particles_get_at_element_id_value)(
                 particles, particle_id );
 
-            for( ; be_it != be_end ; ++be_it, ++io_obj_it )
+            for( ; be_it != be_end ; ++be_it, ++out_obj_it )
             {
-                ptr_particles_t io_particles =
-                    NS(BufferIndex_get_particles)( io_obj_it );
+                ptr_particles_t out_particles =
+                    NS(BufferIndex_get_particles)( out_obj_it );
 
-                NS(Particles_copy_single)( io_particles, particle_id,
+                NS(Particles_copy_single)( out_particles, particle_id,
                                            particles,    particle_id );
 
                 if( 0 != NS(Track_particle_beam_element_obj)(

--- a/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles.cl
+++ b/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles.cl
@@ -25,7 +25,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT elem_by_elem_buf,
-    SIXTRL_UINT64_T const io_particle_blocks_offset );
+    SIXTRL_UINT64_T const out_particle_blocks_offset );
 
 /* ========================================================================= */
 
@@ -264,7 +264,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT elem_by_elem_buf,
-    SIXTRL_UINT64_T const io_particle_blocks_offset )
+    SIXTRL_UINT64_T const out_particle_blocks_offset )
 {
     typedef NS(buffer_size_t)                                   buf_size_t;
     typedef NS(particle_num_elements_t)                         num_element_t;
@@ -285,7 +285,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     obj_const_iter_t be_end = NS(ManagedBuffer_get_const_objects_index_end)(
         belem_buf, slot_size );
 
-    obj_iter_t io_obj_begin = NS(ManagedBuffer_get_objects_index_begin)(
+    obj_iter_t out_obj_begin = NS(ManagedBuffer_get_objects_index_begin)(
         elem_by_elem_buf, slot_size );
 
     obj_iter_t pb_it = NS(ManagedBuffer_get_objects_index_begin)(
@@ -346,7 +346,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
 
     SIXTRL_ASSERT( be_begin     != SIXTRL_NULLPTR );
     SIXTRL_ASSERT( be_end       != SIXTRL_NULLPTR );
-    SIXTRL_ASSERT( io_obj_begin != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( out_obj_begin != SIXTRL_NULLPTR );
 
     SIXTRL_ASSERT( pb_it != SIXTRL_NULLPTR );
 
@@ -363,7 +363,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
         belem_buf, slot_size ) > ( buf_size_t )0u );
 
     SIXTRL_ASSERT( NS(ManagedBuffer_get_num_objects)( elem_by_elem_buf ) >=
-        ( io_particle_blocks_offset + NS(ManagedBuffer_get_num_objects)(
+        ( out_particle_blocks_offset + NS(ManagedBuffer_get_num_objects)(
             belem_buf, slot_size ) ) );
 
     SIXTRL_ASSERT( NS(Particles_managed_buffer_is_particles_buffer)(
@@ -375,11 +375,11 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     SIXTRL_ASSERT( in_particles != SIXTRL_NULLPTR );
     SIXTRL_ASSERT( in_particles->at_element_id != SIXTRL_NULLPTR );
 
-    io_obj_begin = io_obj_begin + io_particle_blocks_offset;
+    out_obj_begin = out_obj_begin + out_particle_blocks_offset;
 
     for( ; particle_index < num_particles ; particle_index += stride )
     {
-        obj_iter_t       io_obj_it = io_obj_begin;
+        obj_iter_t       out_obj_it = out_obj_begin;
         obj_const_iter_t be_it     = be_begin;
 
         NS(Particles_copy_from_generic_addr_data)(
@@ -391,13 +391,13 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
         index_t const particle_id =
             NS(Particles_get_particle_id_value)( &particles, 0u );
 
-        for( ; be_it != be_end ; ++be_it, ++io_obj_it )
+        for( ; be_it != be_end ; ++be_it, ++out_obj_it )
         {
             ptr_particles_t dump_particles = ( ptr_particles_t
-                )NS(Object_get_begin_ptr)( io_obj_it );
+                )NS(Object_get_begin_ptr)( out_obj_it );
 
             SIXTRL_ASSERT( dump_particles != SIXTRL_NULLPTR );
-            SIXTRL_ASSERT( NS(Object_get_type_id)( io_obj_it ) ==
+            SIXTRL_ASSERT( NS(Object_get_type_id)( out_obj_it ) ==
                            NS(OBJECT_TYPE_PARTICLES) );
 
             NS(Particles_copy_to_generic_addr_data)(

--- a/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles_debug.cl
+++ b/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles_debug.cl
@@ -29,7 +29,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT elem_by_elem_buf,
-    SIXTRL_UINT64_T const io_particle_blocks_offset,
+    SIXTRL_UINT64_T const out_particle_blocks_offset,
     SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T* SIXTRL_RESTRICT ptr_success_flag );
 
 /* ========================================================================= */
@@ -303,7 +303,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buf,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT elem_by_elem_buf,
-    SIXTRL_UINT64_T const io_particle_blocks_offset,
+    SIXTRL_UINT64_T const out_particle_blocks_offset,
     SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T* SIXTRL_RESTRICT ptr_success_flag )
 {
     typedef NS(buffer_size_t)                                   buf_size_t;
@@ -332,7 +332,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
         obj_const_iter_t be_end = NS(ManagedBuffer_get_const_objects_index_end)(
             belem_buf, slot_size );
 
-        obj_iter_t io_obj_begin = NS(ManagedBuffer_get_objects_index_begin)(
+        obj_iter_t out_obj_begin = NS(ManagedBuffer_get_objects_index_begin)(
             elem_by_elem_buf, slot_size );
 
         obj_iter_t pb_it = NS(ManagedBuffer_get_objects_index_begin)(
@@ -389,7 +389,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
 
         SIXTRL_ASSERT( be_begin     != SIXTRL_NULLPTR );
         SIXTRL_ASSERT( be_end       != SIXTRL_NULLPTR );
-        SIXTRL_ASSERT( io_obj_begin != SIXTRL_NULLPTR );
+        SIXTRL_ASSERT( out_obj_begin != SIXTRL_NULLPTR );
 
         SIXTRL_ASSERT( pb_it != SIXTRL_NULLPTR );
 
@@ -406,7 +406,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
             belem_buf, slot_size ) > ( buf_size_t )0u );
 
         SIXTRL_ASSERT( NS(ManagedBuffer_get_num_objects)( elem_by_elem_buf ) >=
-            ( io_particle_blocks_offset + NS(ManagedBuffer_get_num_objects)(
+            ( out_particle_blocks_offset + NS(ManagedBuffer_get_num_objects)(
                 belem_buf, slot_size ) ) );
 
         SIXTRL_ASSERT( NS(Particles_managed_buffer_is_particles_buffer)(
@@ -418,12 +418,12 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
         SIXTRL_ASSERT( in_particles != SIXTRL_NULLPTR );
         SIXTRL_ASSERT( in_particles->at_element_id != SIXTRL_NULLPTR );
 
-        io_obj_begin = io_obj_begin + io_particle_blocks_offset;
+        out_obj_begin = out_obj_begin + out_particle_blocks_offset;
         success_flag = ( SIXTRL_INT32_T )0;
 
         for( ; particle_index < num_particles ; particle_index += stride )
         {
-            obj_iter_t       io_obj_it = io_obj_begin;
+            obj_iter_t       out_obj_it = out_obj_begin;
             obj_const_iter_t be_it     = be_begin;
 
             success_flag |= NS(Particles_copy_from_generic_addr_data)(
@@ -435,13 +435,13 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
             index_t const particle_id =
                 NS(Particles_get_particle_id_value)( &particles, 0u );
 
-            for( ; be_it != be_end ; ++be_it, ++io_obj_it )
+            for( ; be_it != be_end ; ++be_it, ++out_obj_it )
             {
                 ptr_particles_t dump_particles = ( ptr_particles_t
-                    )NS(Object_get_begin_ptr)( io_obj_it );
+                    )NS(Object_get_begin_ptr)( out_obj_it );
 
                 SIXTRL_ASSERT( dump_particles != SIXTRL_NULLPTR );
-                SIXTRL_ASSERT( NS(Object_get_type_id)( io_obj_it ) ==
+                SIXTRL_ASSERT( NS(Object_get_type_id)( out_obj_it ) ==
                                NS(OBJECT_TYPE_PARTICLES) );
 
                 success_flag |= NS(Particles_copy_to_generic_addr_data)(

--- a/sixtracklib/sixtracklib.h
+++ b/sixtracklib/sixtracklib.h
@@ -32,7 +32,7 @@
 #include "sixtracklib/common/be_drift/be_drift.h"
 #include "sixtracklib/common/be_drift/track.h"
 #include "sixtracklib/common/be_monitor/be_monitor.h"
-#include "sixtracklib/common/be_monitor/io_buffer.h"
+#include "sixtracklib/common/be_monitor/output_buffer.h"
 #include "sixtracklib/common/be_monitor/track.h"
 #include "sixtracklib/common/be_multipole/be_multipole.h"
 #include "sixtracklib/common/be_multipole/track.h"

--- a/tests/sixtracklib/opencl/test_managed_buffer_opencl.cpp
+++ b/tests/sixtracklib/opencl/test_managed_buffer_opencl.cpp
@@ -1,0 +1,164 @@
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <CL/cl.hpp>
+
+#include "sixtracklib/testlib.h"
+
+#include "sixtracklib/_impl/definitions.h"
+#include "sixtracklib/_impl/path.h"
+#include "sixtracklib/common/impl/managed_buffer.h"
+
+TEST( C99_OpenCLManagedBuffer, InitWithGenericObjDataCopyToDeviceCopyBackCmp )
+{
+    using type_id_t     = ::st_object_type_id_t;
+    using object_t      = ::st_Object;
+    using ptr_to_obj_t  = object_t*;
+    using size_t        = ::st_buffer_size_t;
+    using raw_t         = unsigned char;
+
+    static SIXTRL_CONSTEXPR_OR_CONST size_t SLOTS_ID    = size_t{ 3 };
+    static SIXTRL_CONSTEXPR_OR_CONST size_t OBJECTS_ID  = size_t{ 4 };
+    static SIXTRL_CONSTEXPR_OR_CONST size_t DATAPTRS_ID = size_t{ 5 };
+    static SIXTRL_CONSTEXPR_OR_CONST size_t GARBAGE_ID  = size_t{ 6 };
+
+    size_t const max_num_objects  = size_t{ 2 };
+    size_t const max_num_slots    = size_t{ 8 };
+    size_t const max_num_dataptrs = size_t{ 4 };
+    size_t const max_num_garbage  = size_t{ 1 };
+    size_t const slot_size        = ::st_BUFFER_DEFAULT_SLOT_SIZE;
+
+    size_t const buf_size = st_ManagedBuffer_calculate_buffer_length( nullptr,
+        max_num_objects, max_num_slots, max_num_dataptrs, max_num_garbage );
+
+    size_t current_orig_buffer_size = size_t{ 0 };
+
+    ASSERT_TRUE( buf_size > size_t{ 0 } );
+
+    std::vector< raw_t > orig_buffer( buf_size, raw_t{ 0 } );
+    std::vector< raw_t > copy_buffer( buf_size, raw_t{ 0 } );
+
+    int success = ::st_ManagedBuffer_init( orig_buffer.data(),
+        &current_orig_buffer_size, max_num_objects, max_num_slots,
+            max_num_dataptrs, max_num_garbage, orig_buffer.size(), slot_size );
+
+    ASSERT_TRUE( success == 0 );
+    ASSERT_TRUE( current_orig_buffer_size <= orig_buffer.size() );
+    ASSERT_TRUE( current_orig_buffer_size <= copy_buffer.size() );
+
+    ptr_to_obj_t obj_it  = reinterpret_cast< ptr_to_obj_t >(
+        st_ManagedBuffer_get_ptr_to_section_data(
+            orig_buffer.data(), OBJECTS_ID, slot_size ) );
+
+    ptr_to_obj_t  obj_end = obj_it;
+    std::advance( obj_end, ::st_ManagedBuffer_get_section_num_entities(
+        orig_buffer.data(), OBJECTS_ID, slot_size );
+
+    /* --------------------------------------------------------------------- */
+
+    std::vector< cl::Platform > platform;
+    cl::Platform::get( &platform );
+
+    if( platform.empty() )
+    {
+        std::cout << "Unable to perform unit-test as no OpenCL "
+                  << "platforms have been found."
+                  << std::endl;
+
+        return 0;
+    }
+
+    std::vector< cl::Device > devices;
+
+    for( auto const& p : platform )
+    {
+        std::vector< cl::Device > temp_devices;
+
+        p.getDevices( CL_DEVICE_TYPE_ALL, &temp_devices );
+
+        for( auto const& d : temp_devices )
+        {
+            if( !d.getInfo< CL_DEVICE_AVAILABLE >() ) continue;
+            devices.push_back( d );
+        }
+    }
+
+    std::ostringstream a2str;
+
+    a2str << "#if !defined( SIXTRL_NO_INCLUDES ) \r\n"
+        << "    #include \"sixtracklib/_impl/definitions.h\"\r\n"
+        << "    #include \"sixtracklib/common/impl/managed_buffer_minimal.h\"\r\n"
+        << "    #include \"sixtracklib/common/impl/managed_buffer_remap.h\"\r\n"
+        << "#endif /* !defined( SIXTRL_NO_INCLUDES ) */\r\n"
+        << "\r\n"
+        << "#include \"test_managed_buffer_opencl_kernel.cl\" \r\n"
+        << "\r\n";
+
+    std::string const PROGRAM_SOURCE_CODE = a2str.str();
+
+    a2str.str( "" );
+    a2str << " -D_GPUCODE=1"
+          << " -D__NAMESPACE=st_"
+          << " -I" << ::st_PATH_TO_BASE_DIR )
+          << " -I" << ::st_PATH_TO_BASE_DIR << "tests/sixtracklib/opencl";
+
+    std::string const COMPILE_OPTIONS = a2str.str();
+
+    for( auto& device : devices )
+    {
+        std::fill( copy_buffer.begin(), copy_buffer.end(), raw_t{ 0 } );
+
+        size_t current_copy_buffer_size = size_t{ 0 };
+
+        success = ::st_ManagedBuffer_init( orig_buffer.data(),
+            &current_copy_buf_size, max_num_objects, max_num_slots,
+                max_num_dataptrs, max_num_garbage, orig_buffer.size(),
+                    slot_size );
+
+        ASSERT_TRUE( success == 0 );
+        ASSERT_TRUE( current_orig_buffer_size == current_copy_buffer_size );
+
+        cl_int cl_ret = ::CL_SUCCESS;
+
+        cl::Context context( device );
+        cl::CommandQueue queue( context, device, CL_QUEUE_PROFILING_ENABLE );
+        cl::Program program( context, PROGRAM_SOURCE_CODE );
+
+        try
+        {
+            cl_ret = program.build( COMPILE_OPTIONS.c_str() );
+        }
+        catch( cl::Error const& e )
+        {
+            std::cerr << "OpenCL Compilation Error -> Stopping Unit-Test \r\n"
+                      << program.getBuildInfo< CL_PROGRAM_BUILD_LOG >( device )
+                      << "\r\n"
+                      << std::endl;
+
+            cl_ret = CL_FALSE;
+            throw;
+        }
+
+        ASSERT_TRUE( cl_ret == CL_SUCCESS );
+
+        cl::Buffer cl_orig_buffer(
+            context, CL_MEM_READ_WRITE, current_orig_buffer_size );
+
+        cl::Buffer cl_copy_buffer(
+            context, CL_MEM_WRITE_ONLY, current_copy_buffer_size );
+
+
+    }
+
+
+
+}
+
+/* end: tests/sixtracklib/opencl/test_managed_buffer_opencl.cpp */

--- a/tests/sixtracklib/testlib/common/beam_elements.c
+++ b/tests/sixtracklib/testlib/common/beam_elements.c
@@ -368,19 +368,21 @@ void NS(BeamMonitor_fprint)(
     int const attr_cont =
         NS(BeamMonitor_are_attributes_continous)( monitor ) ? 1 : 0;
 
+    SIXTRL_ASSERT( monitor != SIXTRL_NULLPTR );
+
     fprintf( fp,
-            "|beam-monitor     | num stores      = %20d \r\n"
-            "                  | start turn      = %20d;\r\n"
-            "                  | skip turns      = %20d;\r\n"
-            "                  | io_address      = %20lu;\r\n"
-            "                  | io store stride = %20lu;\r\n"
-            "                  | rolling         = %20d;\r\n"
-            "                  | cont attributes = %20d;\r\n",
+            "|beam-monitor     | num stores       = %20d \r\n"
+            "                  | start turn       = %20d;\r\n"
+            "                  | skip turns       = %20d;\r\n"
+            "                  | out_address      = %20lu;\r\n"
+            "                  | out store stride = %20lu;\r\n"
+            "                  | rolling          = %20d;\r\n"
+            "                  | cont attributes  = %20d;\r\n",
             ( int )NS(BeamMonitor_get_num_stores)( monitor ),
             ( int )NS(BeamMonitor_get_start)( monitor ),
             ( int )NS(BeamMonitor_get_skip)( monitor ),
-            ( unsigned long )NS(BeamMonitor_get_io_address)( monitor ),
-            ( unsigned long )NS(BeamMonitor_get_io_store_stride)( monitor ),
+            ( unsigned long )NS(BeamMonitor_get_out_address)( monitor ),
+            ( unsigned long )monitor->out_store_stride,
             is_rolling, attr_cont );
 
     return;

--- a/tests/sixtracklib/testlib/common/beam_elements.h
+++ b/tests/sixtracklib/testlib/common/beam_elements.h
@@ -341,18 +341,20 @@ SIXTRL_INLINE void NS(BeamMonitor_print)(
     int const attr_cont =
         NS(BeamMonitor_are_attributes_continous)( monitor ) ? 1 : 0;
 
-    printf( "|beam-monitor     | num stores      = %20d \r\n"
-            "                  | start turn      = %20d;\r\n"
-            "                  | skip turns      = %20d;\r\n"
-            "                  | io_address      = %20lu;\r\n"
-            "                  | io store stride = %20lu;\r\n"
-            "                  | rolling         = %20d;\r\n"
-            "                  | cont attributes = %20d;\r\n",
+    SIXTRL_ASSERT( monitor != SIXTRL_NULLPTR );
+
+    printf( "|beam-monitor     | num stores       = %20d \r\n"
+            "                  | start turn       = %20d;\r\n"
+            "                  | skip turns       = %20d;\r\n"
+            "                  | out address      = %20lu;\r\n"
+            "                  | out store stride = %20lu;\r\n"
+            "                  | rolling          = %20d;\r\n"
+            "                  | cont attributes  = %20d;\r\n",
             ( int )NS(BeamMonitor_get_num_stores)( monitor ),
             ( int )NS(BeamMonitor_get_start)( monitor ),
             ( int )NS(BeamMonitor_get_skip)( monitor ),
-            ( unsigned long )NS(BeamMonitor_get_io_address)( monitor ),
-            ( unsigned long )NS(BeamMonitor_get_io_store_stride)( monitor ),
+            ( unsigned long )NS(BeamMonitor_get_out_address)( monitor ),
+            ( unsigned long )monitor->out_store_stride,
             is_rolling, attr_cont );
 
     return;


### PR DESCRIPTION
Summary:

1) Change IO buffer to Output Buffer where it only refers to the dump-storage of the BeamMonitor. Examples track_io and track_io_opencl are not renamed since they still take input

2) Storage space is calculated using the maximum particle_id of the input NS(Particle). Duplicate entries of particle_id should result in a non-successfull preparation of the Output buffer. Cf. unit test tests/sixtracklib/common/test_particles_c99, testcase InitRandomParticleIdsCheckDuplicatesMinMaxParticleIds 

3) Remove the num_particles argument from the calls to prepare and assign the Output buffer. Preparation is now done using an instance of the NS(Particles) with the proper particle_id, all other functions reconstruct the num_particles from the prepared NS(Particles) structure in the output buffer

4) Update OpenCL Kernels and OpenCL context to reflect these changes
5) Update the OpenCL related unit-test
6) Update the examples/c99/track_io and examples/c99/track_io_opencl accordingly
7) Provide a convenience function NS(Particles_init_particle_ids)( particles) to init the particle_ids with the canonical set of numbers