### PR TITLE
sixtracklib: Update signature and semantics of NS(TrackJob*_track)()

### DIFF
--- a/examples/c99/track_job_cpu.c
+++ b/examples/c99/track_job_cpu.c
@@ -95,10 +95,13 @@ int main( int argc, char* argv[] )
         st_TrackJobCpu* track_job = st_TrackJobCpu_new(
             pb, eb, 0, NUM_TURNS_ELEM_BY_ELEM );
 
+        /* get the pointer to the output buffer */
+        st_Buffer const* output_buffer =
+            st_TrackJobCpu_get_output_buffer( track_job );
+
         /* Track until NUM_TURNS_ELEM_BY_ELEM + 3: */
         int const TRACK_UNTIL_T2 = NUM_TURNS_ELEM_BY_ELEM + 3;
-        st_Buffer const* output_buffer =
-            st_TrackJobCpu_track( track_job ,TRACK_UNTIL_T2 );
+        st_TrackJobCpu_track( track_job ,TRACK_UNTIL_T2 );
 
         /* if we want to get the intermediate results for the particle_buffer
          * itself, we have to call NS(TrackJobCpu_collec)() */
@@ -110,7 +113,7 @@ int main( int argc, char* argv[] )
         st_Particles_buffer_print_out( temp_particles_buffer );
 
         /* Track until NUM_TURNS: */
-        output_buffer = st_TrackJobCpu_track( track_job, NUM_TURNS );
+        st_TrackJobCpu_track( track_job, NUM_TURNS );
 
         st_Particles_buffer_print_out( output_buffer );
 

--- a/examples/c99/track_job_opencl.c
+++ b/examples/c99/track_job_opencl.c
@@ -100,10 +100,12 @@ int main( int argc, char* argv[] )
         st_ClContext const* context = st_TrackJobCl_get_const_context( track_job );
         st_ClContextBase_print_nodes_info( context );
 
+        st_Buffer const* output_buffer =
+            st_TrackJobCl_get_output_buffer( track_job );
+
         /* Track until NUM_TURNS_ELEM_BY_ELEM + 3: */
         int const TRACK_UNTIL_T2 = NUM_TURNS_ELEM_BY_ELEM + 3;
-        st_Buffer const* output_buffer =
-            st_TrackJobCl_track( track_job ,TRACK_UNTIL_T2 );
+        st_TrackJobCl_track( track_job ,TRACK_UNTIL_T2 );
 
         /* if we want to get the intermediate results for the particle_buffer
          * itself, we have to call NS(TrackJobCpu_collec)() */
@@ -115,7 +117,7 @@ int main( int argc, char* argv[] )
         st_Particles_buffer_print_out( temp_particles_buffer );
 
         /* Track until NUM_TURNS: */
-        output_buffer = st_TrackJobCl_track( track_job, NUM_TURNS );
+        st_TrackJobCl_track( track_job, NUM_TURNS );
 
         st_Particles_buffer_print_out( output_buffer );
 

--- a/sixtracklib/common/internal/track_job_cpu.cpp
+++ b/sixtracklib/common/internal/track_job_cpu.cpp
@@ -138,8 +138,7 @@ namespace SIXTRL_CXX_NAMESPACE
         }
     }
 
-    TrackJobCpu::c_buffer_t*
-    TrackJobCpu::track( TrackJobCpu::size_type const until_turn )
+    bool TrackJobCpu::track( TrackJobCpu::size_type const until_turn )
     {
         SIXTRL_ASSERT( this->doGetPtrParticlesBuffer()    != nullptr );
         SIXTRL_ASSERT( this->doGetPtrBeamElementsBuffer() != nullptr );
@@ -153,9 +152,7 @@ namespace SIXTRL_CXX_NAMESPACE
         int ret = NS(Track_all_particles_until_turn)(
             particles, this->doGetPtrBeamElementsBuffer(), until_turn );
 
-        ( void )ret;
-
-        return this->doGetPtrOutputBuffer();
+        return ( ret == 0 );
     }
 
     void TrackJobCpu::collect()
@@ -205,11 +202,11 @@ SIXTRL_HOST_FN void NS(TrackJobCpu_delete)(
     return;
 }
 
-SIXTRL_HOST_FN NS(Buffer)* NS(TrackJobCpu_track)(
+SIXTRL_HOST_FN bool NS(TrackJobCpu_track)(
     NS(TrackJobCpu)* SIXTRL_RESTRICT track_job,
     NS(buffer_size_t) const until_turn )
 {
-    return ( track_job != nullptr ) ? track_job->track( until_turn ) : nullptr;
+    return ( track_job != nullptr ) ? track_job->track( until_turn ) : false;
 }
 
 SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCpu_collect)(

--- a/sixtracklib/common/track_job_cpu.h
+++ b/sixtracklib/common/track_job_cpu.h
@@ -49,7 +49,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
         virtual ~TrackJobCpu() SIXTRL_NOEXCEPT;
 
-        c_buffer_t* track( size_type const until_turn );
+        bool track( size_type const until_turn );
 
         void collect();
 
@@ -93,7 +93,7 @@ NS(TrackJobCpu_new_using_output_buffer)(
 SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCpu_delete)(
     NS(TrackJobCpu)* SIXTRL_RESTRICT track_job );
 
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(Buffer)* NS(TrackJobCpu_track)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCpu_track)(
     NS(TrackJobCpu)* SIXTRL_RESTRICT track_job,
     NS(buffer_size_t) const until_turn );
 

--- a/sixtracklib/opencl/internal/track_job_cl.cpp
+++ b/sixtracklib/opencl/internal/track_job_cl.cpp
@@ -199,8 +199,7 @@ namespace SIXTRL_CXX_NAMESPACE
         }
     }
 
-    TrackJobCl::c_buffer_t* TrackJobCl::track(
-        TrackJobCl::size_type const until_turn )
+    bool TrackJobCl::track( TrackJobCl::size_type const until_turn )
     {
         using size_t = TrackJobCl::size_type;
 
@@ -216,19 +215,7 @@ namespace SIXTRL_CXX_NAMESPACE
                 this->m_ptr_beam_elements_buffer_arg.get(),
                 until_turn ) );
 
-        if( success )
-        {
-            this->m_ptr_output_buffer_arg->read(
-                this->doGetPtrOutputBuffer() );
-
-            unsigned char* output_buffer_data_begin =
-                ::NS(Buffer_get_data_begin)( this->doGetPtrOutputBuffer() );
-
-            success &= ( 0 == ::NS(ManagedBuffer_remap)(
-                output_buffer_data_begin, slot_size ) );
-        }
-
-        return ( success ) ? this->doGetPtrOutputBuffer() : nullptr;
+        return success;
     }
 
     void TrackJobCl::collect()
@@ -471,12 +458,12 @@ SIXTRL_HOST_FN void NS(TrackJobCl_delete)(
     delete track_job;
 }
 
-SIXTRL_HOST_FN NS(Buffer)* NS(TrackJobCl_track)(
+SIXTRL_HOST_FN bool NS(TrackJobCl_track)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
     NS(buffer_size_t) const until_turn )
 {
     return ( track_job != nullptr )
-        ? track_job->track( until_turn ) : nullptr;
+        ? track_job->track( until_turn ) : false;
 }
 
 SIXTRL_HOST_FN NS(ClContext)*

--- a/sixtracklib/opencl/track_job_cl.h
+++ b/sixtracklib/opencl/track_job_cl.h
@@ -63,7 +63,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
         virtual ~TrackJobCl();
 
-        c_buffer_t* track( size_type const until_turn );
+        bool track( size_type const until_turn );
 
         void collect();
 
@@ -149,7 +149,7 @@ NS(TrackJobCl_new_using_output_buffer)(
 SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCl_delete)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job );
 
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(Buffer)* NS(TrackJobCl_track)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCl_track)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
     NS(buffer_size_t) const until_turn );
 
@@ -165,30 +165,6 @@ SIXTRL_EXTERN SIXTRL_HOST_FN NS(Buffer)* NS(TrackJobCl_get_output_buffer)(
 SIXTRL_EXTERN SIXTRL_HOST_FN NS(Buffer)*
 NS(TrackJobCl_get_beam_elements_buffer)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job );
-
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(TrackJobCl)* NS(TrackJobCl_new)(
-    char const* SIXTRL_RESTRICT device_id_str,
-    NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
-    NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
-    NS(buffer_size_t) const num_elem_by_elem_turns,
-    NS(buffer_size_t) const until_turn );
-
-
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(TrackJobCl)*
-NS(TrackJobCl_new_using_output_buffer)(
-    char const* SIXTRL_RESTRICT device_id_str,
-    NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
-    NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
-    NS(Buffer)* SIXTRL_RESTRICT output_buffer,
-    NS(buffer_size_t) const num_elem_by_elem_turns,
-    NS(buffer_size_t) const until_turn );
-
-SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCl_delete)(
-    NS(TrackJobCl)* SIXTRL_RESTRICT track_job );
-
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(Buffer)* NS(TrackJobCl_track)(
-    NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
-    NS(buffer_size_t) const until_turn );
 
 SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClContext)*
 NS(TrackJobCl_get_context)( NS(TrackJobCl)* SIXTRL_RESTRICT track_job );

--- a/tests/sixtracklib/common/test_track_job_cpu_c99.cpp
+++ b/tests/sixtracklib/common/test_track_job_cpu_c99.cpp
@@ -75,8 +75,7 @@ TEST( C99_TrackJobCpuTests, MinimalExample )
 
     for( ; ii < NUM_TURNS_TOTAL ; ++ii )
     {
-        ::st_Buffer* output_buffer = ::st_TrackJobCpu_track( track_job, ii );
-        ASSERT_TRUE( output_buffer != nullptr );
+        ASSERT_TRUE( ::st_TrackJobCpu_track( track_job, ii ) );
     }
 
     ::st_TrackJobCpu_collect( track_job );

--- a/tests/sixtracklib/opencl/test_track_job_opencl_c99.cpp
+++ b/tests/sixtracklib/opencl/test_track_job_opencl_c99.cpp
@@ -75,8 +75,7 @@ TEST( C99_TrackJobClTests, MinimalExample )
 
     for( ; ii < NUM_TURNS_TOTAL ; ++ii )
     {
-        ::st_Buffer* output_buffer = ::st_TrackJobCl_track( track_job, ii );
-        ASSERT_TRUE( output_buffer != nullptr );
+        ASSERT_TRUE( ::st_TrackJobCl_track( track_job, ii ) );
     }
 
     ::st_TrackJobCl_collect( track_job );


### PR DESCRIPTION
Change the return type of the _track)() functions from st_Buffer* to bool
No longer automatically collect the output buffer
