### PR TITLE
sixtracklib: added a (dummy) elem by elem tracking function to the API

### DIFF
--- a/sixtracklib/common/internal/track_job_cpu.cpp
+++ b/sixtracklib/common/internal/track_job_cpu.cpp
@@ -155,6 +155,12 @@ namespace SIXTRL_CXX_NAMESPACE
         return ( ret == 0 );
     }
 
+    bool TrackJobCpu::trackElemByElem( TrackJobCpu::size_type const until_turn )
+    {
+        ( void )until_turn;
+        return false;
+    }
+
     void TrackJobCpu::collect()
     {
         return;
@@ -207,6 +213,14 @@ SIXTRL_HOST_FN bool NS(TrackJobCpu_track)(
     NS(buffer_size_t) const until_turn )
 {
     return ( track_job != nullptr ) ? track_job->track( until_turn ) : false;
+}
+
+SIXTRL_HOST_FN bool NS(TrackJobCpu_track_elem_by_elem)(
+    NS(TrackJobCpu)* SIXTRL_RESTRICT track_job,
+    NS(buffer_size_t) const until_turn )
+{
+    return ( track_job != nullptr )
+        ? track_job->trackElemByElem( until_turn ) : false;
 }
 
 SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCpu_collect)(

--- a/sixtracklib/common/track_job_cpu.h
+++ b/sixtracklib/common/track_job_cpu.h
@@ -50,6 +50,7 @@ namespace SIXTRL_CXX_NAMESPACE
         virtual ~TrackJobCpu() SIXTRL_NOEXCEPT;
 
         bool track( size_type const until_turn );
+        bool trackElemByElem( size_type const until_turn );
 
         void collect();
 
@@ -94,6 +95,10 @@ SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCpu_delete)(
     NS(TrackJobCpu)* SIXTRL_RESTRICT track_job );
 
 SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCpu_track)(
+    NS(TrackJobCpu)* SIXTRL_RESTRICT track_job,
+    NS(buffer_size_t) const until_turn );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCpu_track_elem_by_elem)(
     NS(TrackJobCpu)* SIXTRL_RESTRICT track_job,
     NS(buffer_size_t) const until_turn );
 

--- a/sixtracklib/opencl/internal/track_job_cl.cpp
+++ b/sixtracklib/opencl/internal/track_job_cl.cpp
@@ -218,6 +218,12 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
+    bool TrackJobCl::trackElemByElem( TrackJobCl::size_type const until_turn )
+    {
+        ( void )until_turn;
+        return false;
+    }
+
     void TrackJobCl::collect()
     {
         using size_t = TrackJobCl::size_type;
@@ -464,6 +470,14 @@ SIXTRL_HOST_FN bool NS(TrackJobCl_track)(
 {
     return ( track_job != nullptr )
         ? track_job->track( until_turn ) : false;
+}
+
+SIXTRL_HOST_FN bool NS(TrackJobCl_track_elem_by_elem)(
+    NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
+    NS(buffer_size_t) const until_turn )
+{
+    return ( track_job != nullptr )
+        ? track_job->trackElemByElem( until_turn ) : false;
 }
 
 SIXTRL_HOST_FN NS(ClContext)*

--- a/sixtracklib/opencl/track_job_cl.h
+++ b/sixtracklib/opencl/track_job_cl.h
@@ -64,6 +64,7 @@ namespace SIXTRL_CXX_NAMESPACE
         virtual ~TrackJobCl();
 
         bool track( size_type const until_turn );
+        bool trackElemByElem( size_type const until_turn );
 
         void collect();
 
@@ -150,6 +151,10 @@ SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCl_delete)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job );
 
 SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCl_track)(
+    NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
+    NS(buffer_size_t) const until_turn );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCl_track_elem_by_elem)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
     NS(buffer_size_t) const until_turn );
 


### PR DESCRIPTION
Added trackElemByElem() (c++) and track_elem_by_elem() (c99) functions
to the API
